### PR TITLE
fix(dhl-shipping): add return address for DHL Retoure service

### DIFF
--- a/docs/Parcel.NET.Docs/wwwroot/api-docs.json
+++ b/docs/Parcel.NET.Docs/wwwroot/api-docs.json
@@ -829,7 +829,7 @@
         "name": "ReturnAddressContact",
         "kind": "Property",
         "type": "ContactInfo",
-        "description": "Gets the contact information for the . Only applied when is set."
+        "description": "Gets the contact information for the return address. Only applied when ReturnAddress is set."
       }
     ]
   },

--- a/docs/Parcel.NET.Docs/wwwroot/api-docs.json
+++ b/docs/Parcel.NET.Docs/wwwroot/api-docs.json
@@ -818,6 +818,18 @@
         "kind": "Property",
         "type": "string",
         "description": "Gets the billing number for the return shipment."
+      },
+      {
+        "name": "ReturnAddress",
+        "kind": "Property",
+        "type": "Address",
+        "description": "Gets the return address the parcel is sent back to. If not specified, the shipment\u0027s shipper address is used."
+      },
+      {
+        "name": "ReturnAddressContact",
+        "kind": "Property",
+        "type": "ContactInfo",
+        "description": "Gets the contact information for the . Only applied when is set."
       }
     ]
   },

--- a/src/Parcel.NET.Dhl.Shipping/DhlShippingClient.cs
+++ b/src/Parcel.NET.Dhl.Shipping/DhlShippingClient.cs
@@ -251,7 +251,7 @@ public class DhlShippingClient : IShipmentService, IDhlShippingClient
                             }
                             : null
                     },
-                    Services = MapServices(request.ValueAddedServices),
+                    Services = MapServices(request.ValueAddedServices, request.Shipper, request.ShipperContact),
                     Customs = MapCustoms(request.CustomsDetails)
                 }
             ]
@@ -271,6 +271,25 @@ public class DhlShippingClient : IShipmentService, IDhlShippingClient
             Country = address.CountryCode,
             Email = contact?.Email,
             ContactName = contact?.Name
+        };
+
+    // DHL models VASDhlRetoure.returnAddress as a ContactAddress (not a Shipper),
+    // so it carries state, phone and contact name in addition to the postal fields.
+    private static DhlApiContactAddress MapReturnAddress(Address address, ContactInfo? contact) =>
+        new()
+        {
+            Name1 = address.Name,
+            Name2 = address.Name2,
+            Name3 = address.Name3,
+            AddressStreet = address.Street ?? throw new ArgumentException("Return address street is required."),
+            AddressHouse = address.HouseNumber,
+            PostalCode = address.PostalCode,
+            City = address.City,
+            State = address.State,
+            Country = address.CountryCode,
+            ContactName = contact?.Name,
+            Phone = contact?.Phone,
+            Email = contact?.Email
         };
 
     private static object MapConsignee(Address address, ContactInfo? contact, DhlConsignee? dhlConsignee)
@@ -328,7 +347,7 @@ public class DhlShippingClient : IShipmentService, IDhlShippingClient
         };
     }
 
-    private static DhlApiServices? MapServices(DhlValueAddedServices? vas)
+    private static DhlApiServices? MapServices(DhlValueAddedServices? vas, Address shipperAddress, ContactInfo? shipperContact)
     {
         if (vas is null)
             return null;
@@ -384,7 +403,10 @@ public class DhlShippingClient : IShipmentService, IDhlShippingClient
             DhlRetoure = vas.DhlRetoure is not null
                 ? new DhlApiRetoure
                 {
-                    BillingNumber = vas.DhlRetoure.BillingNumber
+                    BillingNumber = vas.DhlRetoure.BillingNumber,
+                    ReturnAddress = vas.DhlRetoure.ReturnAddress is not null
+                        ? MapReturnAddress(vas.DhlRetoure.ReturnAddress, vas.DhlRetoure.ReturnAddressContact)
+                        : MapReturnAddress(shipperAddress, shipperContact)
                 }
                 : null
         };

--- a/src/Parcel.NET.Dhl.Shipping/Internal/DhlApiModels.cs
+++ b/src/Parcel.NET.Dhl.Shipping/Internal/DhlApiModels.cs
@@ -339,8 +339,9 @@ internal class DhlApiRetoure
     [JsonPropertyName("billingNumber")]
     public required string BillingNumber { get; set; }
 
+    // DHL Parcel DE Shipping API v2: VASDhlRetoure.returnAddress is a ContactAddress.
     [JsonPropertyName("returnAddress")]
-    public DhlApiShipper? ReturnAddress { get; set; }
+    public DhlApiContactAddress? ReturnAddress { get; set; }
 }
 
 internal class DhlApiMonetaryValue

--- a/src/Parcel.NET.Dhl.Shipping/Models/DhlValueAddedServices.cs
+++ b/src/Parcel.NET.Dhl.Shipping/Models/DhlValueAddedServices.cs
@@ -177,8 +177,8 @@ public class DhlRetoureService
     public Address? ReturnAddress { get; init; }
 
     /// <summary>
-    /// Gets the contact information for the return address.
-    /// Only applied when ReturnAddress is set.
+    /// Gets the contact information for the return address.
+    /// Only applied when ReturnAddress is set.
     /// </summary>
     public ContactInfo? ReturnAddressContact { get; init; }
 }

--- a/src/Parcel.NET.Dhl.Shipping/Models/DhlValueAddedServices.cs
+++ b/src/Parcel.NET.Dhl.Shipping/Models/DhlValueAddedServices.cs
@@ -177,8 +177,8 @@ public class DhlRetoureService
     public Address? ReturnAddress { get; init; }
 
     /// <summary>
-    /// Gets the contact information for the <see cref="ReturnAddress"/>.
-    /// Only applied when <see cref="ReturnAddress"/> is set.
+    /// Gets the contact information for the return address.
+    /// Only applied when ReturnAddress is set.
     /// </summary>
     public ContactInfo? ReturnAddressContact { get; init; }
 }

--- a/src/Parcel.NET.Dhl.Shipping/Models/DhlValueAddedServices.cs
+++ b/src/Parcel.NET.Dhl.Shipping/Models/DhlValueAddedServices.cs
@@ -1,3 +1,5 @@
+using Parcel.NET.Abstractions.Models;
+
 namespace Parcel.NET.Dhl.Shipping.Models;
 
 /// <summary>
@@ -167,4 +169,16 @@ public class DhlRetoureService
 {
     /// <summary>Gets the billing number for the return shipment.</summary>
     public required string BillingNumber { get; init; }
+
+    /// <summary>
+    /// Gets the return address the parcel is sent back to.
+    /// If not specified, the shipment's shipper address is used.
+    /// </summary>
+    public Address? ReturnAddress { get; init; }
+
+    /// <summary>
+    /// Gets the contact information for the <see cref="ReturnAddress"/>.
+    /// Only applied when <see cref="ReturnAddress"/> is set.
+    /// </summary>
+    public ContactInfo? ReturnAddressContact { get; init; }
 }

--- a/tests/Parcel.NET.Dhl.Shipping.Tests/DhlShippingClientTests.cs
+++ b/tests/Parcel.NET.Dhl.Shipping.Tests/DhlShippingClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Parcel.NET.Abstractions.Exceptions;
 using Parcel.NET.Abstractions.Models;
 using Parcel.NET.Dhl.Shipping.Models;
@@ -361,6 +362,192 @@ public class DhlShippingClientTests
 
         var body = await handler.LastRequest!.Content!.ReadAsStringAsync();
         body.ShouldContain("\"poBoxID\":456");
+    }
+
+    [Fact]
+    public async Task CreateShipmentAsync_Retoure_WithoutReturnAddress_UsesShipperAddress()
+    {
+        var handler = new MockHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new
+            {
+                status = new { title = "OK", statusCode = 200 },
+                items = new[] { new { shipmentNo = "123", label = new { b64 = Convert.ToBase64String("pdf"u8.ToArray()) }, sstatus = new { title = "OK", statusCode = 200 } } }
+            })
+        });
+
+        var client = new DhlShippingClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api-sandbox.dhl.com/parcel/de/shipping/v2/")
+        });
+
+        var baseRequest = CreateTestRequest();
+        var retoureRequest = new DhlShipmentRequest
+        {
+            BillingNumber = baseRequest.BillingNumber,
+            Profile = baseRequest.Profile,
+            Product = baseRequest.Product,
+            Shipper = baseRequest.Shipper,
+            ShipperContact = new ContactInfo { Name = "Shipper Contact", Phone = "+49 228 1" },
+            Consignee = baseRequest.Consignee,
+            Packages = baseRequest.Packages,
+            ValueAddedServices = new DhlValueAddedServices
+            {
+                DhlRetoure = new DhlRetoureService { BillingNumber = "33333333330101" }
+            }
+        };
+
+        await client.CreateShipmentAsync(retoureRequest);
+
+        var body = await handler.LastRequest!.Content!.ReadAsStringAsync();
+        var returnAddress = GetReturnAddress(body);
+        // Return address falls back to the shipper address (incl. shipper contact).
+        returnAddress.GetProperty("name1").GetString().ShouldBe("Test Shipper");
+        returnAddress.GetProperty("postalCode").GetString().ShouldBe("53113");
+        returnAddress.GetProperty("phone").GetString().ShouldBe("+49 228 1");
+    }
+
+    [Fact]
+    public async Task CreateShipmentAsync_Retoure_WithReturnAddress_UsesReturnAddress()
+    {
+        var handler = new MockHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new
+            {
+                status = new { title = "OK", statusCode = 200 },
+                items = new[] { new { shipmentNo = "123", label = new { b64 = Convert.ToBase64String("pdf"u8.ToArray()) }, sstatus = new { title = "OK", statusCode = 200 } } }
+            })
+        });
+
+        var client = new DhlShippingClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api-sandbox.dhl.com/parcel/de/shipping/v2/")
+        });
+
+        var request = new DhlShipmentRequest
+        {
+            BillingNumber = "33333333330101",
+            Profile = "STANDARD_GRUPPENPROFIL",
+            Product = DhlProduct.V01PAK,
+            Shipper = new Address { Name = "Test Shipper", Street = "Teststraße", HouseNumber = "1", PostalCode = "53113", City = "Bonn", CountryCode = "DEU" },
+            Consignee = new Address { Name = "Test Consignee", Street = "Empfängerstraße", HouseNumber = "10", PostalCode = "10117", City = "Berlin", CountryCode = "DEU" },
+            Packages = [new Package { Weight = 1.5 }],
+            ValueAddedServices = new DhlValueAddedServices
+            {
+                DhlRetoure = new DhlRetoureService
+                {
+                    BillingNumber = "33333333330101",
+                    ReturnAddress = new Address
+                    {
+                        Name = "Retoure Receiver",
+                        Street = "Return Street",
+                        HouseNumber = "9",
+                        PostalCode = "20095",
+                        City = "Hamburg",
+                        State = "HH",
+                        CountryCode = "DEU"
+                    },
+                    ReturnAddressContact = new ContactInfo { Name = "Return Desk", Phone = "+49 40 123" }
+                }
+            }
+        };
+
+        await client.CreateShipmentAsync(request);
+
+        var body = await handler.LastRequest!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var shipment = doc.RootElement.GetProperty("shipments")[0];
+
+        // The explicit return address is used and mapped as a full ContactAddress.
+        var returnAddress = shipment.GetProperty("services").GetProperty("dhlRetoure").GetProperty("returnAddress");
+        returnAddress.GetProperty("name1").GetString().ShouldBe("Retoure Receiver");
+        returnAddress.GetProperty("addressStreet").GetString().ShouldBe("Return Street");
+        returnAddress.GetProperty("postalCode").GetString().ShouldBe("20095");
+        returnAddress.GetProperty("city").GetString().ShouldBe("Hamburg");
+        returnAddress.GetProperty("country").GetString().ShouldBe("DEU");
+        returnAddress.GetProperty("state").GetString().ShouldBe("HH");
+        returnAddress.GetProperty("contactName").GetString().ShouldBe("Return Desk");
+        returnAddress.GetProperty("phone").GetString().ShouldBe("+49 40 123");
+
+        // The shipper block stays independent of the return address.
+        shipment.GetProperty("shipper").GetProperty("name1").GetString().ShouldBe("Test Shipper");
+    }
+
+    [Fact]
+    public async Task CreateShipmentAsync_ValueAddedServicesWithoutRetoure_OmitsDhlRetoure()
+    {
+        var handler = new MockHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new
+            {
+                status = new { title = "OK", statusCode = 200 },
+                items = new[] { new { shipmentNo = "123", label = new { b64 = Convert.ToBase64String("pdf"u8.ToArray()) }, sstatus = new { title = "OK", statusCode = 200 } } }
+            })
+        });
+
+        var client = new DhlShippingClient(new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api-sandbox.dhl.com/parcel/de/shipping/v2/")
+        });
+
+        var baseRequest = CreateTestRequest();
+        var request = new DhlShipmentRequest
+        {
+            BillingNumber = baseRequest.BillingNumber,
+            Profile = baseRequest.Profile,
+            Product = baseRequest.Product,
+            Shipper = baseRequest.Shipper,
+            Consignee = baseRequest.Consignee,
+            Packages = baseRequest.Packages,
+            ValueAddedServices = new DhlValueAddedServices { Premium = true }
+        };
+
+        await client.CreateShipmentAsync(request);
+
+        var body = await handler.LastRequest!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var services = doc.RootElement.GetProperty("shipments")[0].GetProperty("services");
+        // No DhlRetoure set => no dhlRetoure property (and thus no returnAddress) is emitted.
+        services.TryGetProperty("dhlRetoure", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CreateShipmentAsync_RetoureReturnAddressWithoutStreet_ThrowsArgumentException()
+    {
+        var client = CreateClient(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var baseRequest = CreateTestRequest();
+        var request = new DhlShipmentRequest
+        {
+            BillingNumber = baseRequest.BillingNumber,
+            Profile = baseRequest.Profile,
+            Product = baseRequest.Product,
+            Shipper = baseRequest.Shipper,
+            Consignee = baseRequest.Consignee,
+            Packages = baseRequest.Packages,
+            ValueAddedServices = new DhlValueAddedServices
+            {
+                DhlRetoure = new DhlRetoureService
+                {
+                    BillingNumber = "33333333330101",
+                    ReturnAddress = new Address { Name = "No Street", PostalCode = "20095", City = "Hamburg", CountryCode = "DEU" }
+                }
+            }
+        };
+
+        var ex = await Should.ThrowAsync<ArgumentException>(() => client.CreateShipmentAsync(request));
+        ex.Message.ShouldContain("Return address street is required.");
+    }
+
+    private static JsonElement GetReturnAddress(string body)
+    {
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement
+            .GetProperty("shipments")[0]
+            .GetProperty("services")
+            .GetProperty("dhlRetoure")
+            .GetProperty("returnAddress")
+            .Clone();
     }
 
     // --- Unit Conversion Tests ---


### PR DESCRIPTION
## Summary

Fixes #15.

The DHL Parcel DE Shipping API v2 requires a `returnAddress` on `VASDhlRetoure`, but `DhlRetoureService` exposed only a billing number and `MapServices` never populated the field. As a result, any shipment with a return label failed validation with *"ReturnAddress missing"*.

## Changes

- **`DhlRetoureService`**: add optional `ReturnAddress` (`Address`) and `ReturnAddressContact` (`ContactInfo`).
- **Mapping**: `returnAddress` is now mapped as a **`ContactAddress`** — per the [official OpenAPI spec](https://developer.dhl.com/sites/default/files/2026-05/parcel-de-shipping-v2.yaml) `VASDhlRetoure.returnAddress` references `ContactAddress`, not `Shipper`. This carries `state`, `phone` and `contactName` in addition to the postal fields.
- **Fallback**: when no explicit return address is provided, the shipment's shipper address/contact is used (matches the DHL semantics "return goes back to the sender" and the workaround proposed in the issue).
- **Docs**: regenerated `api-docs.json` so the new properties appear in the API reference.

## Behavior / compatibility

Backward compatible: existing code that set only `DhlRetoure.BillingNumber` previously sent **no** return address (validation error). It now sends the shipper address as `returnAddress`, so it starts working without code changes.

## Tests

Added unit tests covering:
- shipper fallback when no return address is set,
- an explicit return address mapped as a full `ContactAddress` (incl. `state`/`phone`/`contactName`),
- omission of `dhlRetoure` when no Retoure is configured,
- the missing-street validation error.

All shipping tests pass (40/40, net10.0).

## Notes

- `additionalAddressInformation1/2` and `dispatchingInformation` from the DHL `ContactAddress` schema are not set because the shared `Address` model does not expose them — no data loss vs. the current model; a dedicated extension would be a separate feature.