### PR TITLE
feat: add LetterXpress (A&O Fischer) API v3 carrier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Test - GoExpress.Shipping
         run: dotnet test tests/Parcel.NET.GoExpress.Shipping.Tests/Parcel.NET.GoExpress.Shipping.Tests.csproj -c Release --no-build -f ${{ matrix.target-framework }}
 
+      - name: Test - LetterXpress.Letters
+        run: dotnet test tests/Parcel.NET.LetterXpress.Letters.Tests/Parcel.NET.LetterXpress.Letters.Tests.csproj -c Release --no-build -f ${{ matrix.target-framework }}
+
       - name: Check for vulnerable packages
         if: matrix.target-framework == 'net10.0'
         run: |
@@ -117,3 +120,4 @@ jobs:
           check_changes "src/Parcel.NET.Abstractions/" "abstractions" "Parcel.NET.Abstractions"
           check_changes "src/Parcel.NET.Dhl/" "dhl" "Parcel.NET.Dhl"
           check_changes "src/Parcel.NET.GoExpress/" "goexpress" "Parcel.NET.GoExpress"
+          check_changes "src/Parcel.NET.LetterXpress/" "letterxpress" "Parcel.NET.LetterXpress"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -20,8 +20,11 @@ on:
           - goexpress
           - goexpress-shipping
           - goexpress-tracking
+          - letterxpress
+          - letterxpress-letters
           - dhl-all
           - goexpress-all
+          - letterxpress-all
           - all
       version:
         description: 'SemVer version (without v prefix, e.g. 1.0.0)'

--- a/.github/workflows/release-letterxpress-all.yml
+++ b/.github/workflows/release-letterxpress-all.yml
@@ -1,0 +1,19 @@
+name: Release Parcel.NET.LetterXpress.All
+
+on:
+  push:
+    tags: ['letterxpress-all/v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-package.yml
+    with:
+      package: 'letterxpress-all'
+      csproj-path: 'src/Parcel.NET.LetterXpress.All/Parcel.NET.LetterXpress.All.csproj'
+      title-prefix: 'Parcel.NET.LetterXpress.All'
+    secrets:
+      nuget-api-key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release-letterxpress-letters.yml
+++ b/.github/workflows/release-letterxpress-letters.yml
@@ -1,0 +1,19 @@
+name: Release Parcel.NET.LetterXpress.Letters
+
+on:
+  push:
+    tags: ['letterxpress-letters/v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-package.yml
+    with:
+      package: 'letterxpress-letters'
+      csproj-path: 'src/Parcel.NET.LetterXpress.Letters/Parcel.NET.LetterXpress.Letters.csproj'
+      title-prefix: 'Parcel.NET.LetterXpress.Letters'
+    secrets:
+      nuget-api-key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release-letterxpress.yml
+++ b/.github/workflows/release-letterxpress.yml
@@ -1,0 +1,19 @@
+name: Release Parcel.NET.LetterXpress
+
+on:
+  push:
+    tags: ['letterxpress/v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/release-package.yml
+    with:
+      package: 'letterxpress'
+      csproj-path: 'src/Parcel.NET.LetterXpress/Parcel.NET.LetterXpress.csproj'
+      title-prefix: 'Parcel.NET.LetterXpress'
+    secrets:
+      nuget-api-key: ${{ secrets.NUGET_API_KEY }}

--- a/Parcel.NET.slnx
+++ b/Parcel.NET.slnx
@@ -19,8 +19,11 @@
     <Project Path="src/Parcel.NET.GoExpress/Parcel.NET.GoExpress.csproj" />
     <Project Path="src/Parcel.NET.GoExpress.Shipping/Parcel.NET.GoExpress.Shipping.csproj" />
     <Project Path="src/Parcel.NET.GoExpress.Tracking/Parcel.NET.GoExpress.Tracking.csproj" />
+    <Project Path="src/Parcel.NET.LetterXpress/Parcel.NET.LetterXpress.csproj" />
+    <Project Path="src/Parcel.NET.LetterXpress.Letters/Parcel.NET.LetterXpress.Letters.csproj" />
     <Project Path="src/Parcel.NET.Dhl.All/Parcel.NET.Dhl.All.csproj" />
     <Project Path="src/Parcel.NET.GoExpress.All/Parcel.NET.GoExpress.All.csproj" />
+    <Project Path="src/Parcel.NET.LetterXpress.All/Parcel.NET.LetterXpress.All.csproj" />
     <Project Path="src/Parcel.NET.All/Parcel.NET.All.csproj" />
   </Folder>
   <Folder Name="/tests/">
@@ -33,5 +36,6 @@
     <Project Path="tests/Parcel.NET.Dhl.LocationFinder.Tests/Parcel.NET.Dhl.LocationFinder.Tests.csproj" />
     <Project Path="tests/Parcel.NET.GoExpress.Shipping.Tests/Parcel.NET.GoExpress.Shipping.Tests.csproj" />
     <Project Path="tests/Parcel.NET.GoExpress.Tracking.Tests/Parcel.NET.GoExpress.Tracking.Tests.csproj" />
+    <Project Path="tests/Parcel.NET.LetterXpress.Letters.Tests/Parcel.NET.LetterXpress.Letters.Tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Parcel.NET
 
-.NET libraries for logistics carrier APIs. Currently supports **DHL** (Shipping, Tracking, Pickup, Returns, Internetmarke, Location Finder) and **GO! Express** (Shipping, Tracking) — all targeting .NET 8, 9, and 10.
+.NET libraries for logistics carrier APIs. Currently supports **DHL** (Shipping, Tracking, Pickup, Returns, Internetmarke, Location Finder), **GO! Express** (Shipping, Tracking), and **LetterXpress** (Letters / SMART@MAIL) — all targeting .NET 8, 9, and 10.
 
 [![CI](https://github.com/emuuu/Parcel.NET/actions/workflows/ci.yml/badge.svg)](https://github.com/emuuu/Parcel.NET/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -21,9 +21,10 @@
 - DHL Unified Location Finder v1 — search by address, geo-coordinates, or keyword
 - GO! Express Shipping — create, cancel shipments, label generation
 - GO! Express Tracking — track shipments
+- LetterXpress API v3 — print jobs, SMART@MAIL e-mail jobs, balance, price, transactions, invoices
 - Builder-pattern DI registration with typed `HttpClient` pipeline
 - OAuth ROPC, API key, and Basic Auth — handled automatically per carrier
-- Sandbox support for DHL and GO! Express
+- Sandbox / test mode support for DHL, GO! Express, and LetterXpress
 
 ## Packages
 
@@ -43,15 +44,19 @@
 | `Parcel.NET.GoExpress` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.GoExpress.svg)](https://www.nuget.org/packages/Parcel.NET.GoExpress) | GO! Express authentication, configuration, and DI extensions |
 | `Parcel.NET.GoExpress.Shipping` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.GoExpress.Shipping.svg)](https://www.nuget.org/packages/Parcel.NET.GoExpress.Shipping) | GO! Express Shipping client |
 | `Parcel.NET.GoExpress.Tracking` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.GoExpress.Tracking.svg)](https://www.nuget.org/packages/Parcel.NET.GoExpress.Tracking) | GO! Express Tracking client |
+| **LetterXpress** | | |
+| `Parcel.NET.LetterXpress` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.LetterXpress.svg)](https://www.nuget.org/packages/Parcel.NET.LetterXpress) | LetterXpress authentication, configuration, and DI extensions |
+| `Parcel.NET.LetterXpress.Letters` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.LetterXpress.Letters.svg)](https://www.nuget.org/packages/Parcel.NET.LetterXpress.Letters) | LetterXpress API v3 client (print jobs, SMART@MAIL e-mail jobs, price, balance, transactions, invoices) |
 | **Meta-Packages** | | |
 | `Parcel.NET.Dhl.All` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.Dhl.All.svg)](https://www.nuget.org/packages/Parcel.NET.Dhl.All) | All DHL packages |
 | `Parcel.NET.GoExpress.All` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.GoExpress.All.svg)](https://www.nuget.org/packages/Parcel.NET.GoExpress.All) | All GO! Express packages |
+| `Parcel.NET.LetterXpress.All` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.LetterXpress.All.svg)](https://www.nuget.org/packages/Parcel.NET.LetterXpress.All) | All LetterXpress packages |
 | `Parcel.NET.All` | [![NuGet](https://img.shields.io/nuget/v/Parcel.NET.All.svg)](https://www.nuget.org/packages/Parcel.NET.All) | All Parcel.NET packages |
 
 ## Prerequisites
 
 - .NET 8.0, 9.0, or 10.0
-- A DHL developer account and/or GO! Express credentials
+- A DHL developer account, GO! Express credentials, and/or a LetterXpress account
 
 ## Installation
 
@@ -60,10 +65,12 @@
 dotnet add package Parcel.NET.Dhl.Shipping
 dotnet add package Parcel.NET.Dhl.Tracking
 dotnet add package Parcel.NET.GoExpress.Shipping
+dotnet add package Parcel.NET.LetterXpress.Letters
 
 # Or install everything for a carrier
 dotnet add package Parcel.NET.Dhl.All
 dotnet add package Parcel.NET.GoExpress.All
+dotnet add package Parcel.NET.LetterXpress.All
 
 # Or install all carriers at once
 dotnet add package Parcel.NET.All
@@ -105,6 +112,41 @@ builder.Services.AddGoExpress(options =>
 .AddGoExpressShipping()
 .AddGoExpressTracking();
 ```
+
+### 2b. Register LetterXpress services
+
+```csharp
+builder.Services.AddLetterXpress(options =>
+{
+    options.Username = "your-username";
+    options.ApiKey = "your-api-key";
+    options.UseTestMode = true; // jobs go to the Postbox instead of being processed
+})
+.AddLetterXpressLetters();
+```
+
+Send a letter as a print job:
+
+```csharp
+var letterXpress = serviceProvider.GetRequiredService<ILetterXpressClient>();
+
+var balance = await letterXpress.GetBalanceAsync();
+
+var job = await letterXpress.CreatePrintJobAsync(new LetterRequest
+{
+    File = await File.ReadAllBytesAsync("invoice.pdf"),
+    Specification = new LetterSpecification
+    {
+        Color = LetterColor.BlackWhite,
+        Mode = PrintMode.Simplex,
+        Shipping = ShippingType.National
+    }
+});
+```
+
+> **Note:** The LetterXpress API is rate-limited to 120 requests/minute and accepts at most 50 MB per request.
+> The client validates the 50 MB limit locally; throttling/retry on HTTP 429 is left to the caller's `HttpClient`
+> pipeline (e.g. a `Microsoft.Extensions.Http.Resilience` handler).
 
 ### 3. Create a shipment
 

--- a/docs/Parcel.NET.Docs.Generator/Parcel.NET.Docs.Generator.csproj
+++ b/docs/Parcel.NET.Docs.Generator/Parcel.NET.Docs.Generator.csproj
@@ -21,6 +21,8 @@
     <ProjectReference Include="../../src/Parcel.NET.Dhl.Tracking/Parcel.NET.Dhl.Tracking.csproj" />
     <ProjectReference Include="../../src/Parcel.NET.GoExpress/Parcel.NET.GoExpress.csproj" />
     <ProjectReference Include="../../src/Parcel.NET.GoExpress.Shipping/Parcel.NET.GoExpress.Shipping.csproj" />
+    <ProjectReference Include="../../src/Parcel.NET.LetterXpress/Parcel.NET.LetterXpress.csproj" />
+    <ProjectReference Include="../../src/Parcel.NET.LetterXpress.Letters/Parcel.NET.LetterXpress.Letters.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/Parcel.NET.Docs.Generator/Program.cs
+++ b/docs/Parcel.NET.Docs.Generator/Program.cs
@@ -103,7 +103,9 @@ async Task GenerateApiDocs(string wwwrootPath)
         typeof(Parcel.NET.Dhl.Shipping.IDhlShippingClient).Assembly,
         typeof(Parcel.NET.Dhl.Tracking.DhlTrackingClient).Assembly,
         typeof(Parcel.NET.GoExpress.GoExpressOptions).Assembly,
-        typeof(Parcel.NET.GoExpress.Shipping.IGoExpressShippingClient).Assembly
+        typeof(Parcel.NET.GoExpress.Shipping.IGoExpressShippingClient).Assembly,
+        typeof(Parcel.NET.LetterXpress.LetterXpressOptions).Assembly,
+        typeof(Parcel.NET.LetterXpress.Letters.ILetterXpressClient).Assembly
     };
 
     var xmlDocs = new Dictionary<string, XDocument>();

--- a/docs/Parcel.NET.Docs/wwwroot/api-docs.json
+++ b/docs/Parcel.NET.Docs/wwwroot/api-docs.json
@@ -1570,5 +1570,1037 @@
         "description": "Gets or sets the weekend or holiday indicator for this time window."
       }
     ]
+  },
+  {
+    "typeName": "LetterXpressBuilder",
+    "fullName": "Parcel.NET.LetterXpress.LetterXpressBuilder",
+    "members": [
+      {
+        "name": "Services",
+        "kind": "Property",
+        "type": "IServiceCollection",
+        "description": "Gets the underlying service collection."
+      }
+    ]
+  },
+  {
+    "typeName": "LetterXpressOptions",
+    "fullName": "Parcel.NET.LetterXpress.LetterXpressOptions",
+    "members": [
+      {
+        "name": "Username",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the LetterXpress account username. Generated under \u0022Mein Konto \u003E Zugangsdaten \u003E LXP API\u0022."
+      },
+      {
+        "name": "ApiKey",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the LetterXpress API key. Generated under \u0022Mein Konto \u003E Zugangsdaten \u003E LXP API\u0022."
+      },
+      {
+        "name": "UseTestMode",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets or sets a value indicating whether to use the LetterXpress test mode. In test mode (\u0022mode\u0022: \u0022test\u0022) submitted jobs are not processed but stored in the \u0022Postbox\u0022 where they can be reviewed, deleted, or sent. Postbox jobs are deleted after 7 days. When , jobs are processed directly (\u0022mode\u0022: \u0022live\u0022)."
+      },
+      {
+        "name": "CustomBaseUrl",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets a custom base URL override. When set, this takes precedence over the default production URL."
+      },
+      {
+        "name": "BaseUrl",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the effective API base URL. Uses if set, otherwise the production URL. A trailing slash is appended if missing so that relative request URIs (e.g. balance, printjobs) resolve correctly."
+      }
+    ]
+  },
+  {
+    "typeName": "LetterXpressServiceCollectionExtensions",
+    "fullName": "Parcel.NET.LetterXpress.LetterXpressServiceCollectionExtensions",
+    "members": [
+      {
+        "name": "AddLetterXpress(IServiceCollection, Action\u003CLetterXpressOptions\u003E)",
+        "kind": "Method",
+        "type": "LetterXpressBuilder",
+        "description": null
+      }
+    ]
+  },
+  {
+    "typeName": "Balance",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.Balance",
+    "members": [
+      {
+        "name": "Amount",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the current balance."
+      },
+      {
+        "name": "Currency",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the currency (e.g. EUR)."
+      }
+    ]
+  },
+  {
+    "typeName": "BankForm",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.BankForm",
+    "members": [
+      {
+        "name": "Included",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets or sets a value indicating whether the bank form is already included in the PDF\u0027s last sheet. When , the payment detail fields below are ignored and the last (blank) sheet is used."
+      },
+      {
+        "name": "Payee",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the payee. Max. 27 characters. Ignored when is ."
+      },
+      {
+        "name": "Iban",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the IBAN. Max. 34 characters."
+      },
+      {
+        "name": "Bic",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the BIC. Max. 11 characters."
+      },
+      {
+        "name": "Amount",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the amount. Max. 12 characters."
+      },
+      {
+        "name": "PurposeOfPayment",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the purpose of payment. Max. 27 characters."
+      },
+      {
+        "name": "PurposeOfPayment2",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the second purpose of payment line. Max. 27 characters."
+      }
+    ]
+  },
+  {
+    "typeName": "EmailJob",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.EmailJob",
+    "members": [
+      {
+        "name": "Id",
+        "kind": "Property",
+        "type": "Int64",
+        "description": "Gets the e-mail job ID."
+      },
+      {
+        "name": "EmailSender",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the sender e-mail address."
+      },
+      {
+        "name": "EmailReceiver",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the recipient e-mail address."
+      },
+      {
+        "name": "EmailOption",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the SMART@MAIL option (maildirect, mailplus, mailsecure)."
+      },
+      {
+        "name": "SentAt",
+        "kind": "Property",
+        "type": "DateTimeOffset?",
+        "description": "Gets the timestamp the e-mail was sent, if available."
+      },
+      {
+        "name": "Amount",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the net amount charged."
+      },
+      {
+        "name": "Vat",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the VAT."
+      },
+      {
+        "name": "Status",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the job status (e.g. queue, hold, success)."
+      },
+      {
+        "name": "Subject",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the e-mail subject."
+      },
+      {
+        "name": "Content",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the e-mail content."
+      },
+      {
+        "name": "Footer",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the e-mail footer."
+      },
+      {
+        "name": "CreatedAt",
+        "kind": "Property",
+        "type": "DateTimeOffset?",
+        "description": "Gets the creation timestamp."
+      },
+      {
+        "name": "PrintJobId",
+        "kind": "Property",
+        "type": "Int64?",
+        "description": "Gets the ID of the associated print job, when the e-mail job is part of a serial response."
+      },
+      {
+        "name": "PrintJob",
+        "kind": "Property",
+        "type": "PrintJob",
+        "description": "Gets the associated print job, returned for MailPlus jobs."
+      }
+    ]
+  },
+  {
+    "typeName": "EmailJobResult",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.EmailJobResult",
+    "members": [
+      {
+        "name": "EmailJobs",
+        "kind": "Property",
+        "type": "IReadOnlyList\u003CEmailJob\u003E",
+        "description": "Gets the created e-mail jobs."
+      },
+      {
+        "name": "PrintJobs",
+        "kind": "Property",
+        "type": "IReadOnlyList\u003CPrintJob\u003E",
+        "description": "Gets any print jobs created alongside the e-mail jobs (e.g. for MailPlus or pages without a white code)."
+      }
+    ]
+  },
+  {
+    "typeName": "EmailLetterOptions",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.EmailLetterOptions",
+    "members": [
+      {
+        "name": "EmailOption",
+        "kind": "Property",
+        "type": "EmailOption",
+        "description": "Gets or sets the SMART@MAIL delivery option."
+      },
+      {
+        "name": "EmailReceiver",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the valid recipient e-mail address."
+      }
+    ]
+  },
+  {
+    "typeName": "ILetterXpressClient",
+    "fullName": "Parcel.NET.LetterXpress.Letters.ILetterXpressClient",
+    "members": [
+      {
+        "name": "GetBalanceAsync(CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CBalance\u003E",
+        "description": null
+      },
+      {
+        "name": "GetPriceAsync(PriceRequest, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPriceResult\u003E",
+        "description": null
+      },
+      {
+        "name": "ListPrintJobsAsync(PrintJobFilter?, int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CPrintJob\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "CreatePrintJobAsync(LetterRequest, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPrintJob\u003E",
+        "description": null
+      },
+      {
+        "name": "GetPrintJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPrintJob\u003E",
+        "description": null
+      },
+      {
+        "name": "UpdatePrintJobAsync(Int64, PrintJobUpdate, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPrintJob\u003E",
+        "description": null
+      },
+      {
+        "name": "DeletePrintJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task",
+        "description": null
+      },
+      {
+        "name": "CreateEmailJobAsync(LetterRequest, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CEmailJobResult\u003E",
+        "description": null
+      },
+      {
+        "name": "GetEmailJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CEmailJob\u003E",
+        "description": null
+      },
+      {
+        "name": "UpdateEmailJobAsync(Int64, string, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CEmailJob\u003E",
+        "description": null
+      },
+      {
+        "name": "DeleteEmailJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task",
+        "description": null
+      },
+      {
+        "name": "ListEmailJobsAsync(EmailJobFilter?, int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CEmailJob\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "ListTransactionsAsync(TransactionFilter?, int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CTransaction\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "ListInvoicesAsync(int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CInvoice\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "GetInvoiceAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CInvoice\u003E",
+        "description": null
+      }
+    ]
+  },
+  {
+    "typeName": "Invoice",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.Invoice",
+    "members": [
+      {
+        "name": "Id",
+        "kind": "Property",
+        "type": "Int64",
+        "description": "Gets the invoice ID."
+      },
+      {
+        "name": "Amount",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the net amount."
+      },
+      {
+        "name": "Vat",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the VAT."
+      },
+      {
+        "name": "InvoiceDate",
+        "kind": "Property",
+        "type": "DateOnly?",
+        "description": "Gets the invoice date."
+      },
+      {
+        "name": "Base64Data",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the invoice PDF as base64, returned only when retrieving a single invoice."
+      }
+    ]
+  },
+  {
+    "typeName": "LetterBackgrounds",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.LetterBackgrounds",
+    "members": [
+      {
+        "name": "FirstPage",
+        "kind": "Property",
+        "type": "byte[]",
+        "description": "Gets or sets the background PDF for the first page."
+      },
+      {
+        "name": "OtherPages",
+        "kind": "Property",
+        "type": "byte[]",
+        "description": "Gets or sets the background PDF for all other pages."
+      }
+    ]
+  },
+  {
+    "typeName": "LetterRequest",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.LetterRequest",
+    "members": [
+      {
+        "name": "File",
+        "kind": "Property",
+        "type": "byte[]",
+        "description": "Gets or sets the letter PDF as raw bytes. Max. 50 MB."
+      },
+      {
+        "name": "Specification",
+        "kind": "Property",
+        "type": "LetterSpecification",
+        "description": "Gets or sets the print and shipping specification."
+      },
+      {
+        "name": "FilenameOriginal",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the original file name (e.g. Rechnung-123456.pdf). Optional; necessary for LXP SMART@MAIL and returned when retrieving jobs."
+      },
+      {
+        "name": "Registered",
+        "kind": "Property",
+        "type": "RegisteredMail",
+        "description": "Gets or sets the registered mail option. Registered mail can only be sent nationally. Defaults to ."
+      },
+      {
+        "name": "DispatchDate",
+        "kind": "Property",
+        "type": "DateOnly?",
+        "description": "Gets or sets the dispatch date. Optional; must be in the future."
+      },
+      {
+        "name": "SerialLetter",
+        "kind": "Property",
+        "type": "SerialLetterOptions",
+        "description": "Gets or sets serial letter options. Cannot be combined with ."
+      },
+      {
+        "name": "EmailLetter",
+        "kind": "Property",
+        "type": "EmailLetterOptions",
+        "description": "Gets or sets LXP SMART@MAIL e-mail options for a single job. Cannot be combined with ."
+      },
+      {
+        "name": "Attachments",
+        "kind": "Property",
+        "type": "IReadOnlyList\u003Cbyte[]\u003E",
+        "description": "Gets or sets additional attachments as raw PDF bytes. Each attachment must be A4 portrait (29.7 x 21.0 cm). The order is preserved."
+      },
+      {
+        "name": "Backgrounds",
+        "kind": "Property",
+        "type": "LetterBackgrounds",
+        "description": "Gets or sets the letter background PDFs."
+      },
+      {
+        "name": "TermsAndConditions",
+        "kind": "Property",
+        "type": "TermsAndConditions",
+        "description": "Gets or sets the terms and conditions PDF."
+      },
+      {
+        "name": "BankForm",
+        "kind": "Property",
+        "type": "BankForm",
+        "description": "Gets or sets the bank transfer form."
+      },
+      {
+        "name": "Notice",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets an arbitrary notice stored with the job. Max. 255 characters."
+      }
+    ]
+  },
+  {
+    "typeName": "LetterSpecification",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.LetterSpecification",
+    "members": [
+      {
+        "name": "Color",
+        "kind": "Property",
+        "type": "LetterColor",
+        "description": "Gets or sets the print color. Defaults to ."
+      },
+      {
+        "name": "Mode",
+        "kind": "Property",
+        "type": "PrintMode",
+        "description": "Gets or sets the print mode. Defaults to ."
+      },
+      {
+        "name": "Shipping",
+        "kind": "Property",
+        "type": "ShippingType",
+        "description": "Gets or sets the shipping destination. Defaults to ."
+      },
+      {
+        "name": "C4",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets or sets a value indicating whether to use a C4 envelope. Optional, applies to letters under 9 sheets."
+      }
+    ]
+  },
+  {
+    "typeName": "LetterXpressClient",
+    "fullName": "Parcel.NET.LetterXpress.Letters.LetterXpressClient",
+    "members": [
+      {
+        "name": "GetBalanceAsync(CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CBalance\u003E",
+        "description": null
+      },
+      {
+        "name": "GetPriceAsync(PriceRequest, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPriceResult\u003E",
+        "description": null
+      },
+      {
+        "name": "ListPrintJobsAsync(PrintJobFilter?, int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CPrintJob\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "CreatePrintJobAsync(LetterRequest, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPrintJob\u003E",
+        "description": null
+      },
+      {
+        "name": "GetPrintJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPrintJob\u003E",
+        "description": null
+      },
+      {
+        "name": "UpdatePrintJobAsync(Int64, PrintJobUpdate, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPrintJob\u003E",
+        "description": null
+      },
+      {
+        "name": "DeletePrintJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task",
+        "description": null
+      },
+      {
+        "name": "CreateEmailJobAsync(LetterRequest, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CEmailJobResult\u003E",
+        "description": null
+      },
+      {
+        "name": "GetEmailJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CEmailJob\u003E",
+        "description": null
+      },
+      {
+        "name": "UpdateEmailJobAsync(Int64, string, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CEmailJob\u003E",
+        "description": null
+      },
+      {
+        "name": "DeleteEmailJobAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task",
+        "description": null
+      },
+      {
+        "name": "ListEmailJobsAsync(EmailJobFilter?, int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CEmailJob\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "ListTransactionsAsync(TransactionFilter?, int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CTransaction\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "ListInvoicesAsync(int?, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CPagedResult\u003CInvoice\u003E\u003E",
+        "description": null
+      },
+      {
+        "name": "GetInvoiceAsync(Int64, CancellationToken)",
+        "kind": "Method",
+        "type": "Task\u003CInvoice\u003E",
+        "description": null
+      }
+    ]
+  },
+  {
+    "typeName": "LetterXpressLettersExtensions",
+    "fullName": "Parcel.NET.LetterXpress.Letters.LetterXpressLettersExtensions",
+    "members": [
+      {
+        "name": "AddLetterXpressLetters(LetterXpressBuilder)",
+        "kind": "Method",
+        "type": "LetterXpressBuilder",
+        "description": null
+      }
+    ]
+  },
+  {
+    "typeName": "PagedResult\u00601",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.PagedResult\u00601",
+    "members": [
+      {
+        "name": "Items",
+        "kind": "Property",
+        "type": "IReadOnlyList\u003CT\u003E",
+        "description": "Gets the items on the current page."
+      },
+      {
+        "name": "Pagination",
+        "kind": "Property",
+        "type": "Pagination",
+        "description": "Gets the pagination metadata, if available."
+      }
+    ]
+  },
+  {
+    "typeName": "Pagination",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.Pagination",
+    "members": [
+      {
+        "name": "Total",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets the total number of items."
+      },
+      {
+        "name": "Count",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets the number of items on the current page."
+      },
+      {
+        "name": "CurrentPage",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets the current page number."
+      },
+      {
+        "name": "LastPage",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets the last page number."
+      },
+      {
+        "name": "PerPage",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets the number of items per page."
+      },
+      {
+        "name": "FirstPageUrl",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the URL of the first page, if any."
+      },
+      {
+        "name": "LastPageUrl",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the URL of the last page, if any."
+      },
+      {
+        "name": "NextPageUrl",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the URL of the next page, if any."
+      },
+      {
+        "name": "PrevPageUrl",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the URL of the previous page, if any."
+      }
+    ]
+  },
+  {
+    "typeName": "PriceRequest",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.PriceRequest",
+    "members": [
+      {
+        "name": "Pages",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets or sets the number of pages."
+      },
+      {
+        "name": "Color",
+        "kind": "Property",
+        "type": "LetterColor",
+        "description": "Gets or sets the print color. Defaults to ."
+      },
+      {
+        "name": "Mode",
+        "kind": "Property",
+        "type": "PrintMode",
+        "description": "Gets or sets the print mode. Defaults to ."
+      },
+      {
+        "name": "Shipping",
+        "kind": "Property",
+        "type": "ShippingType",
+        "description": "Gets or sets the shipping destination. Only and are valid for price requests."
+      },
+      {
+        "name": "C4",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets or sets a value indicating whether to use a C4 envelope."
+      },
+      {
+        "name": "EmailOption",
+        "kind": "Property",
+        "type": "EmailOption?",
+        "description": "Gets or sets the SMART@MAIL e-mail option. Optional."
+      },
+      {
+        "name": "Registered",
+        "kind": "Property",
+        "type": "RegisteredMail",
+        "description": "Gets or sets the registered mail option. Optional; only national shipping is supported for registered mail."
+      }
+    ]
+  },
+  {
+    "typeName": "PriceResult",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.PriceResult",
+    "members": [
+      {
+        "name": "Price",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the calculated gross price."
+      },
+      {
+        "name": "Pages",
+        "kind": "Property",
+        "type": "int?",
+        "description": "Gets the number of pages the price was calculated for."
+      },
+      {
+        "name": "Color",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the print color the price was calculated for."
+      },
+      {
+        "name": "Mode",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the print mode the price was calculated for."
+      },
+      {
+        "name": "Shipping",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the shipping destination the price was calculated for."
+      }
+    ]
+  },
+  {
+    "typeName": "PrintJob",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.PrintJob",
+    "members": [
+      {
+        "name": "Id",
+        "kind": "Property",
+        "type": "Int64",
+        "description": "Gets the print job ID."
+      },
+      {
+        "name": "Shipping",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the shipping destination (e.g. national)."
+      },
+      {
+        "name": "Mode",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the print mode (e.g. simplex)."
+      },
+      {
+        "name": "Color",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the print color (1 for black/white, 4 for color)."
+      },
+      {
+        "name": "C4",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets a value indicating whether a C4 envelope is used."
+      },
+      {
+        "name": "Registered",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the registered mail option (r1, r2), if any."
+      },
+      {
+        "name": "BankForm",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets a value indicating whether a bank form is attached."
+      },
+      {
+        "name": "Notice",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the notice stored with the job."
+      },
+      {
+        "name": "Status",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the job status (e.g. queue, hold, done, canceled, draft)."
+      },
+      {
+        "name": "DispatchDate",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the dispatch date, if set."
+      },
+      {
+        "name": "FilenameOriginal",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the original file name, if provided."
+      },
+      {
+        "name": "CreatedAt",
+        "kind": "Property",
+        "type": "DateTimeOffset?",
+        "description": "Gets the creation timestamp. The API reports times in German local time (Europe/Berlin)."
+      },
+      {
+        "name": "UpdatedAt",
+        "kind": "Property",
+        "type": "DateTimeOffset?",
+        "description": "Gets the last update timestamp. The API reports times in German local time (Europe/Berlin)."
+      },
+      {
+        "name": "Items",
+        "kind": "Property",
+        "type": "IReadOnlyList\u003CPrintJobItem\u003E",
+        "description": "Gets the recipient items of the job."
+      }
+    ]
+  },
+  {
+    "typeName": "PrintJobItem",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.PrintJobItem",
+    "members": [
+      {
+        "name": "Address",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the recipient address as a single line."
+      },
+      {
+        "name": "Pages",
+        "kind": "Property",
+        "type": "int",
+        "description": "Gets the number of pages."
+      },
+      {
+        "name": "Amount",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the net amount charged for this item."
+      },
+      {
+        "name": "Vat",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the VAT for this item."
+      },
+      {
+        "name": "Status",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the item status (e.g. queue, sent)."
+      },
+      {
+        "name": "TrackingCode",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the registered mail tracking code, if available."
+      },
+      {
+        "name": "Base64Data",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the rendered letter PDF as base64, returned only when retrieving a single job."
+      }
+    ]
+  },
+  {
+    "typeName": "PrintJobUpdate",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.PrintJobUpdate",
+    "members": [
+      {
+        "name": "DispatchDate",
+        "kind": "Property",
+        "type": "DateOnly?",
+        "description": "Gets or sets the new dispatch date."
+      },
+      {
+        "name": "Registered",
+        "kind": "Property",
+        "type": "RegisteredMail?",
+        "description": "Gets or sets the new registered mail option."
+      },
+      {
+        "name": "Notice",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the new notice."
+      },
+      {
+        "name": "Color",
+        "kind": "Property",
+        "type": "LetterColor?",
+        "description": "Gets or sets the new print color."
+      },
+      {
+        "name": "Mode",
+        "kind": "Property",
+        "type": "PrintMode?",
+        "description": "Gets or sets the new print mode."
+      },
+      {
+        "name": "Shipping",
+        "kind": "Property",
+        "type": "ShippingType?",
+        "description": "Gets or sets the new shipping destination."
+      },
+      {
+        "name": "C4",
+        "kind": "Property",
+        "type": "bool?",
+        "description": "Gets or sets the new C4 envelope flag."
+      }
+    ]
+  },
+  {
+    "typeName": "SerialLetterOptions",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.SerialLetterOptions",
+    "members": [
+      {
+        "name": "PagesSeparatorType",
+        "kind": "Property",
+        "type": "SeparatorType",
+        "description": "Gets or sets the separator type."
+      },
+      {
+        "name": "PagesSeparatorValue",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets or sets the separator value: a keyword when is , or a page count when it is ."
+      }
+    ]
+  },
+  {
+    "typeName": "TermsAndConditions",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.TermsAndConditions",
+    "members": [
+      {
+        "name": "Terms",
+        "kind": "Property",
+        "type": "byte[]",
+        "description": "Gets or sets the terms and conditions PDF."
+      },
+      {
+        "name": "OnAllPages",
+        "kind": "Property",
+        "type": "bool",
+        "description": "Gets or sets a value indicating whether the terms are inserted behind all pages () or only behind the first page ()."
+      }
+    ]
+  },
+  {
+    "typeName": "Transaction",
+    "fullName": "Parcel.NET.LetterXpress.Letters.Models.Transaction",
+    "members": [
+      {
+        "name": "Amount",
+        "kind": "Property",
+        "type": "Decimal",
+        "description": "Gets the amount (negative for charges, positive for top-ups)."
+      },
+      {
+        "name": "Currency",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the currency (e.g. EUR)."
+      },
+      {
+        "name": "Description",
+        "kind": "Property",
+        "type": "string",
+        "description": "Gets the description."
+      },
+      {
+        "name": "CreatedAt",
+        "kind": "Property",
+        "type": "DateTimeOffset?",
+        "description": "Gets the creation timestamp."
+      }
+    ]
   }
 ]

--- a/docs/Parcel.NET.Docs/wwwroot/content-index.json
+++ b/docs/Parcel.NET.Docs/wwwroot/content-index.json
@@ -62,6 +62,28 @@
     "searchText": "Overview The GoExpressShippingClient implements the GO! Express Realtime Order \u0026amp; Label API (GO! Connect), providing: Shipment creation with label generation Label re-generation for existing shipments Shipment cancellation Important: AX4 Web-Portal Interaction If you also use the AX4 Web-Portal provided by Siemens, be aware of the following: Delayed visibility : Shipments created via GO! Connect are not immediately visible in the AX4 Web-Portal. They are imported as EDI orders with a delay. C"
   },
   {
+    "slug": "carriers/letterxpress-letters",
+    "title": "LetterXpress Letters",
+    "category": "Carriers",
+    "subcategory": "LetterXpress",
+    "order": 1,
+    "description": "Send physical letters and SMART@MAIL e-mails, query prices and balance, and manage print jobs with the LetterXpress (A\u0026O Fischer) API v3.",
+    "apiRef": "ILetterXpressClient",
+    "headings": [
+      "Overview",
+      "Installation",
+      "Registration",
+      "Authentication \u0026amp; modes",
+      "Examples",
+      "Balance and price",
+      "Create a print job",
+      "SMART@MAIL e-mail job",
+      "Listing and filtering",
+      "Notes \u0026amp; limits"
+    ],
+    "searchText": "Overview LetterXpressClient implements the LetterXpress (A\u0026amp;O Fischer GmbH \u0026amp; Co. KG) API v3 \u2014 a hybrid print-and-mail service: you upload a PDF, LetterXpress prints it and sends it as a physical letter, optionally combined with the SMART@MAIL e-mail product. Because LetterXpress is a letter/print-mail product rather than a parcel carrier, it does not implement the carrier-agnostic IShipmentService / ITrackingService abstractions. It exposes its own ILetterXpressClient interface, mirroring"
+  },
+  {
     "slug": "carriers/dhl-tracking",
     "title": "DHL Tracking",
     "category": "Carriers",

--- a/docs/Parcel.NET.Docs/wwwroot/content/carriers/letterxpress-letters.md
+++ b/docs/Parcel.NET.Docs/wwwroot/content/carriers/letterxpress-letters.md
@@ -1,0 +1,126 @@
+---
+title: LetterXpress Letters
+category: Carriers
+subcategory: LetterXpress
+order: 1
+description: Send physical letters and SMART@MAIL e-mails, query prices and balance, and manage print jobs with the LetterXpress (A&O Fischer) API v3.
+apiRef: ILetterXpressClient
+---
+
+## Overview
+
+`LetterXpressClient` implements the [LetterXpress](https://www.letterxpress.de/) (A&O Fischer GmbH & Co. KG) API v3 — a hybrid print-and-mail service: you upload a PDF, LetterXpress prints it and sends it as a physical letter, optionally combined with the **SMART@MAIL** e-mail product.
+
+Because LetterXpress is a letter/print-mail product rather than a parcel carrier, it does **not** implement the carrier-agnostic `IShipmentService`/`ITrackingService` abstractions. It exposes its own `ILetterXpressClient` interface, mirroring the DHL Internetmarke design.
+
+Supported operations:
+
+- **Account** — query balance and price
+- **Print jobs** — create, retrieve (incl. rendered PDF), update, delete, and list
+- **E-mail jobs (SMART@MAIL)** — create (`maildirect` / `mailplus` / `mailsecure`), retrieve, update, delete, and list
+- **Accounting** — list transactions and invoices (incl. invoice PDF)
+
+## Installation
+
+```bash
+dotnet add package Parcel.NET.LetterXpress.Letters
+# or the meta-package
+dotnet add package Parcel.NET.LetterXpress.All
+```
+
+## Registration
+
+```csharp
+builder.Services.AddLetterXpress(options =>
+{
+    options.Username = "your-username";   // Mein Konto > Zugangsdaten > LXP API
+    options.ApiKey = "your-api-key";
+    options.UseTestMode = true;           // true => Postbox, no real processing
+})
+.AddLetterXpressLetters();
+```
+
+## Authentication & modes
+
+Authentication is sent in the JSON **body** of every request (an `auth` object with `username`, `apikey`, and `mode`) — there is no auth header. The client handles this for you.
+
+- **Test mode** (`UseTestMode = true`): jobs are placed in the **Postbox** instead of being processed (and therefore not dispatched). Postbox jobs can be reviewed, deleted, or sent, and are deleted automatically after 7 days.
+- **Live mode** (`UseTestMode = false`): jobs are processed and dispatched directly.
+
+> LetterXpress is a server-to-server API and intentionally does **not** enable CORS. Use it from your backend, never directly from a browser — that would expose your API key.
+
+## Examples
+
+### Balance and price
+
+```csharp
+var client = serviceProvider.GetRequiredService<ILetterXpressClient>();
+
+Balance balance = await client.GetBalanceAsync();
+Console.WriteLine($"{balance.Amount} {balance.Currency}");
+
+PriceResult price = await client.GetPriceAsync(new PriceRequest
+{
+    Pages = 1,
+    Color = LetterColor.BlackWhite,
+    Mode = PrintMode.Simplex,
+    Shipping = ShippingType.National   // price supports only National or International
+});
+```
+
+### Create a print job
+
+The PDF is supplied as raw bytes; the client computes the base64 encoding and MD5 checksum automatically.
+
+```csharp
+PrintJob job = await client.CreatePrintJobAsync(new LetterRequest
+{
+    File = await File.ReadAllBytesAsync("invoice.pdf"),
+    FilenameOriginal = "invoice.pdf",
+    Specification = new LetterSpecification
+    {
+        Color = LetterColor.Color,
+        Mode = PrintMode.Duplex,
+        Shipping = ShippingType.National
+    },
+    Registered = RegisteredMail.Einschreiben   // national only
+});
+
+// Within 15 minutes you can still update or delete it:
+await client.UpdatePrintJobAsync(job.Id, new PrintJobUpdate { Notice = "Customer 4711" });
+await client.DeletePrintJobAsync(job.Id);
+```
+
+### SMART@MAIL e-mail job
+
+```csharp
+EmailJobResult result = await client.CreateEmailJobAsync(new LetterRequest
+{
+    File = await File.ReadAllBytesAsync("invoice.pdf"),
+    Specification = new LetterSpecification { Shipping = ShippingType.National },
+    EmailLetter = new EmailLetterOptions
+    {
+        EmailOption = EmailOption.MailDirect,
+        EmailReceiver = "customer@example.com"
+    }
+});
+
+foreach (var email in result.EmailJobs)
+    Console.WriteLine($"{email.Id}: {email.EmailReceiver} ({email.Status})");
+```
+
+### Listing and filtering
+
+```csharp
+PagedResult<PrintJob> queued = await client.ListPrintJobsAsync(PrintJobFilter.Queue);
+PagedResult<EmailJob> sent   = await client.ListEmailJobsAsync(EmailJobFilter.Success);
+PagedResult<Transaction> tx  = await client.ListTransactionsAsync(TransactionFilter.PrintJobs);
+PagedResult<Invoice> invoices = await client.ListInvoicesAsync();
+```
+
+## Notes & limits
+
+- **Limits:** max. 50 MB per request (validated locally) and 120 requests/minute. Throttling/retry on HTTP 429 is left to your `HttpClient` pipeline (e.g. a `Microsoft.Extensions.Http.Resilience` handler).
+- **Timestamps:** the API returns timestamps without a timezone designator, in German local time (Europe/Berlin, CET/CEST). The client parses them into `DateTimeOffset` with the correct (DST-aware) offset.
+- **Constraints enforced by the client:** registered mail is national-only; a serial letter cannot be combined with a single `EmailLetter`; price requests accept only `National`/`International` shipping.
+- **Errors** surface as `LetterXpressException` carrying the HTTP/body status code and the raw response.

--- a/docs/Parcel.NET.Docs/wwwroot/sitemap.xml
+++ b/docs/Parcel.NET.Docs/wwwroot/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://emuuu.github.io/Parcel.NET/docs/api/overview</loc></url>
   <url><loc>https://emuuu.github.io/Parcel.NET/docs/carriers/dhl-shipping</loc></url>
   <url><loc>https://emuuu.github.io/Parcel.NET/docs/carriers/goexpress-shipping</loc></url>
+  <url><loc>https://emuuu.github.io/Parcel.NET/docs/carriers/letterxpress-letters</loc></url>
   <url><loc>https://emuuu.github.io/Parcel.NET/docs/carriers/dhl-tracking</loc></url>
   <url><loc>https://emuuu.github.io/Parcel.NET/docs/carriers/goexpress-tracking</loc></url>
   <url><loc>https://emuuu.github.io/Parcel.NET/docs/carriers/dhl-authentication</loc></url>

--- a/src/Parcel.NET.All/Parcel.NET.All.csproj
+++ b/src/Parcel.NET.All/Parcel.NET.All.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <PackageId>Parcel.NET.All</PackageId>
-    <Description>Meta-package that includes all Parcel.NET carrier packages (DHL, GO! Express).</Description>
-    <PackageTags>shipping;tracking;logistics;dhl;goexpress;parcel;meta-package</PackageTags>
+    <Description>Meta-package that includes all Parcel.NET carrier packages (DHL, GO! Express, LetterXpress).</Description>
+    <PackageTags>shipping;tracking;logistics;dhl;goexpress;letterxpress;parcel;meta-package</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Parcel.NET.Dhl.All\Parcel.NET.Dhl.All.csproj" />
     <ProjectReference Include="..\Parcel.NET.GoExpress.All\Parcel.NET.GoExpress.All.csproj" />
+    <ProjectReference Include="..\Parcel.NET.LetterXpress.All\Parcel.NET.LetterXpress.All.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Parcel.NET.LetterXpress.All/Parcel.NET.LetterXpress.All.csproj
+++ b/src/Parcel.NET.LetterXpress.All/Parcel.NET.LetterXpress.All.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Parcel.NET.LetterXpress.All</PackageId>
+    <Description>Meta-package that includes all LetterXpress (A&amp;O Fischer) carrier packages for Parcel.NET.</Description>
+    <PackageTags>letter;mail;post;logistics;letterxpress;meta-package</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Parcel.NET.LetterXpress\Parcel.NET.LetterXpress.csproj" />
+    <ProjectReference Include="..\Parcel.NET.LetterXpress.Letters\Parcel.NET.LetterXpress.Letters.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Parcel.NET.LetterXpress.Letters/ILetterXpressClient.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/ILetterXpressClient.cs
@@ -1,0 +1,151 @@
+using Parcel.NET.LetterXpress.Letters.Models;
+
+namespace Parcel.NET.LetterXpress.Letters;
+
+/// <summary>
+/// Client for the LetterXpress (A&amp;O Fischer) API v3.
+/// </summary>
+public interface ILetterXpressClient
+{
+    /// <summary>
+    /// Retrieves the account balance (GET /v3/balance).
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The account balance.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<Balance> GetBalanceAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Calculates the price for a letter (GET /v3/price).
+    /// </summary>
+    /// <param name="request">The price request.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The price result.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PriceResult> GetPriceAsync(PriceRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists print jobs (GET /v3/printjobs), ordered from newest to oldest.
+    /// </summary>
+    /// <param name="filter">Optional status filter.</param>
+    /// <param name="page">Optional page number.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A paged list of print jobs.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PagedResult<PrintJob>> ListPrintJobsAsync(PrintJobFilter? filter = null, int? page = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Submits a print job (POST /v3/printjobs).
+    /// </summary>
+    /// <param name="request">The letter to submit.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The created print job.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PrintJob> CreatePrintJobAsync(LetterRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a single print job, including the rendered PDF (GET /v3/printjobs/{id}).
+    /// </summary>
+    /// <param name="id">The print job ID.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The print job.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PrintJob> GetPrintJobAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Changes a print job (PUT /v3/printjobs/{id}). Only possible within the first 15 minutes
+    /// after submission, and the PDF itself cannot be changed.
+    /// </summary>
+    /// <param name="id">The print job ID.</param>
+    /// <param name="update">The changes to apply.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The updated print job.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PrintJob> UpdatePrintJobAsync(long id, PrintJobUpdate update, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a print job (DELETE /v3/printjobs/{id}). Only possible within the first 15 minutes
+    /// after submission; jobs with status <c>done</c> cannot be deleted.
+    /// </summary>
+    /// <param name="id">The print job ID.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task DeletePrintJobAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Submits an e-mail job (POST /v3/emailjobs) using LXP SMART@MAIL.
+    /// </summary>
+    /// <param name="request">The letter to submit. Provide <see cref="LetterRequest.EmailLetter"/> for a single
+    /// job, or omit it and use a white code in the PDF for serial processing.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The created e-mail job(s) and any associated print jobs.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<EmailJobResult> CreateEmailJobAsync(LetterRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a single e-mail job (GET /v3/emailjobs/{id}).
+    /// </summary>
+    /// <param name="id">The e-mail job ID.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The e-mail job.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<EmailJob> GetEmailJobAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Changes an e-mail job's recipient (PUT /v3/emailjobs/{id}). Only possible within the first
+    /// 15 minutes after submission.
+    /// </summary>
+    /// <param name="id">The e-mail job ID.</param>
+    /// <param name="emailReceiver">The new recipient e-mail address.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The updated e-mail job.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<EmailJob> UpdateEmailJobAsync(long id, string emailReceiver, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes an e-mail job (DELETE /v3/emailjobs/{id}). Only possible within the first 15 minutes
+    /// after submission; jobs with status <c>success</c> cannot be deleted.
+    /// </summary>
+    /// <param name="id">The e-mail job ID.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task DeleteEmailJobAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists e-mail jobs (GET /v3/emailjobs).
+    /// </summary>
+    /// <param name="filter">Optional status filter.</param>
+    /// <param name="page">Optional page number.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A paged list of e-mail jobs.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PagedResult<EmailJob>> ListEmailJobsAsync(EmailJobFilter? filter = null, int? page = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists account transactions (GET /v3/transactions).
+    /// </summary>
+    /// <param name="filter">Optional transaction filter.</param>
+    /// <param name="page">Optional page number.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A paged list of transactions.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PagedResult<Transaction>> ListTransactionsAsync(TransactionFilter? filter = null, int? page = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists invoices (GET /v3/invoices).
+    /// </summary>
+    /// <param name="page">Optional page number.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A paged list of invoices.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<PagedResult<Invoice>> ListInvoicesAsync(int? page = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a single invoice, including the PDF (GET /v3/invoices/{id}).
+    /// </summary>
+    /// <param name="id">The invoice ID.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The invoice.</returns>
+    /// <exception cref="LetterXpressException">Thrown when the API returns an error.</exception>
+    Task<Invoice> GetInvoiceAsync(long id, CancellationToken cancellationToken = default);
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Internal/LetterXpressApiModels.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Internal/LetterXpressApiModels.cs
@@ -1,0 +1,262 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Parcel.NET.LetterXpress.Letters.Internal;
+
+// All property names are mapped to snake_case via the JsonContext naming policy,
+// except where an explicit [JsonPropertyName] overrides it (e.g. "apikey").
+
+internal sealed class LxAuth
+{
+    public string Username { get; set; } = "";
+
+    [JsonPropertyName("apikey")]
+    public string ApiKey { get; set; } = "";
+
+    public string Mode { get; set; } = "";
+}
+
+internal sealed class LxAuthRequest
+{
+    public LxAuth Auth { get; set; } = new();
+}
+
+internal sealed class LxSpecificationWire
+{
+    public string? Color { get; set; }
+    public string? Mode { get; set; }
+    public string? Shipping { get; set; }
+    public int? C4 { get; set; }
+    public int? Pages { get; set; }
+    public string? EmailOption { get; set; }
+}
+
+internal sealed class LxSerialWire
+{
+    public string PagesSeparatorType { get; set; } = "";
+
+    // Either a JSON string (keyword) or a JSON number (page count), depending on the separator type.
+    public JsonNode? PagesSeparatorValue { get; set; }
+}
+
+internal sealed class LxEmailLetterWire
+{
+    public string EmailOption { get; set; } = "";
+    public string EmailReceiver { get; set; } = "";
+}
+
+internal sealed class LxBackgroundsWire
+{
+    public string? Base64BackgroundFirstPage { get; set; }
+    public string? Base64BackgroundOtherPages { get; set; }
+}
+
+internal sealed class LxTermsWire
+{
+    public string Base64Terms { get; set; } = "";
+    public int TermsOnAllPages { get; set; }
+}
+
+internal sealed class LxBankFormWire
+{
+    public int BankFormIncluded { get; set; }
+    public string? Payee { get; set; }
+    public string? Iban { get; set; }
+    public string? Bic { get; set; }
+    public string? Amount { get; set; }
+    public string? PurposeOfPayment { get; set; }
+    public string? PurposeOfPayment2 { get; set; }
+}
+
+internal sealed class LxLetterWire
+{
+    public string Base64File { get; set; } = "";
+    public string Base64FileChecksum { get; set; } = "";
+    public LxSpecificationWire Specification { get; set; } = new();
+    public string? FilenameOriginal { get; set; }
+    public string? Registered { get; set; }
+    public string? DispatchDate { get; set; }
+    public LxSerialWire? SerialLetter { get; set; }
+    public LxEmailLetterWire? EmailLetter { get; set; }
+    public List<string>? Base64Attachments { get; set; }
+    public LxBackgroundsWire? Backgrounds { get; set; }
+    public LxTermsWire? TermsAndConditions { get; set; }
+    public LxBankFormWire? BankForm { get; set; }
+    public string? Notice { get; set; }
+}
+
+internal sealed class LxLetterRequest
+{
+    public LxAuth Auth { get; set; } = new();
+    public LxLetterWire Letter { get; set; } = new();
+}
+
+internal sealed class LxPriceLetterWire
+{
+    public LxSpecificationWire Specification { get; set; } = new();
+    public string? Registered { get; set; }
+}
+
+internal sealed class LxPriceRequest
+{
+    public LxAuth Auth { get; set; } = new();
+    public LxPriceLetterWire Letter { get; set; } = new();
+}
+
+internal sealed class LxUpdateLetterWire
+{
+    public string? DispatchDate { get; set; }
+    public string? Registered { get; set; }
+    public string? Notice { get; set; }
+    public LxSpecificationWire? Specification { get; set; }
+}
+
+internal sealed class LxUpdateRequest
+{
+    public LxAuth Auth { get; set; } = new();
+    public LxUpdateLetterWire Letter { get; set; } = new();
+}
+
+internal sealed class LxEmailWire
+{
+    public string EmailReceiver { get; set; } = "";
+}
+
+internal sealed class LxEmailUpdateRequest
+{
+    public LxAuth Auth { get; set; } = new();
+    public LxEmailWire Email { get; set; } = new();
+}
+
+// ---- Response envelopes -------------------------------------------------
+
+internal sealed class LxResponse<T>
+{
+    public int Status { get; set; }
+    public string? Message { get; set; }
+    public T? Data { get; set; }
+}
+
+internal sealed class LxBalanceData
+{
+    public decimal Balance { get; set; }
+    public string? Currency { get; set; }
+}
+
+internal sealed class LxPriceEcho
+{
+    public LxSpecificationWire? Specification { get; set; }
+}
+
+internal sealed class LxPriceData
+{
+    public decimal Price { get; set; }
+    public LxPriceEcho? Letter { get; set; }
+}
+
+internal sealed class LxPrintJobItemWire
+{
+    public string? Address { get; set; }
+    public int Pages { get; set; }
+    public decimal Amount { get; set; }
+    public decimal Vat { get; set; }
+    public string? Status { get; set; }
+    public string? TrackingCode { get; set; }
+    public string? Base64Data { get; set; }
+}
+
+internal sealed class LxPrintJobWire
+{
+    public long Id { get; set; }
+    public string? Shipping { get; set; }
+    public string? Mode { get; set; }
+    public string? Color { get; set; }
+    public int C4 { get; set; }
+    public string? Registered { get; set; }
+    public int BankForm { get; set; }
+    public string? Notice { get; set; }
+    public string? Status { get; set; }
+    public string? DispatchDate { get; set; }
+    public string? FilenameOriginal { get; set; }
+    public string? CreatedAt { get; set; }
+    public string? UpdatedAt { get; set; }
+    public List<LxPrintJobItemWire>? Items { get; set; }
+}
+
+internal sealed class LxPaginationWire
+{
+    public int Total { get; set; }
+    public int Count { get; set; }
+    public int CurrentPage { get; set; }
+    public int LastPage { get; set; }
+    public int PerPage { get; set; }
+    public string? FirstPageUrl { get; set; }
+    public string? LastPageUrl { get; set; }
+    public string? NextPageUrl { get; set; }
+    public string? PrevPageUrl { get; set; }
+}
+
+internal sealed class LxPrintJobsData
+{
+    [JsonPropertyName("printjobs")]
+    public List<LxPrintJobWire>? PrintJobs { get; set; }
+
+    public LxPaginationWire? Pagination { get; set; }
+}
+
+internal sealed class LxEmailJobWire
+{
+    public long Id { get; set; }
+    public string? EmailSender { get; set; }
+    public string? EmailReceiver { get; set; }
+    public string? EmailOption { get; set; }
+    public string? SentAt { get; set; }
+    public decimal Amount { get; set; }
+    public decimal Vat { get; set; }
+    public string? Status { get; set; }
+    public string? Subject { get; set; }
+    public string? Content { get; set; }
+    public string? Footer { get; set; }
+    public string? CreatedAt { get; set; }
+    public long? PrintjobId { get; set; }
+    public LxPrintJobWire? Printjob { get; set; }
+}
+
+internal sealed class LxEmailCreateData
+{
+    [JsonPropertyName("printjobs")]
+    public List<LxPrintJobWire>? PrintJobs { get; set; }
+
+    [JsonPropertyName("emailjobs")]
+    public List<LxEmailJobWire>? EmailJobs { get; set; }
+}
+
+internal sealed class LxTransactionWire
+{
+    public decimal Amount { get; set; }
+    public string? Currency { get; set; }
+    public string? Description { get; set; }
+    public string? CreatedAt { get; set; }
+}
+
+internal sealed class LxTransactionsData
+{
+    public List<LxTransactionWire>? Transactions { get; set; }
+    public LxPaginationWire? Pagination { get; set; }
+}
+
+internal sealed class LxInvoiceWire
+{
+    public long Id { get; set; }
+    public decimal Amount { get; set; }
+    public decimal Vat { get; set; }
+    public string? InvoiceDate { get; set; }
+    public string? Base64Data { get; set; }
+}
+
+internal sealed class LxInvoicesData
+{
+    public List<LxInvoiceWire>? Invoices { get; set; }
+    public LxPaginationWire? Pagination { get; set; }
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Internal/LetterXpressJsonContext.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Internal/LetterXpressJsonContext.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Parcel.NET.LetterXpress.Letters.Internal;
+
+// Requests
+[JsonSerializable(typeof(LxAuthRequest))]
+[JsonSerializable(typeof(LxLetterRequest))]
+[JsonSerializable(typeof(LxPriceRequest))]
+[JsonSerializable(typeof(LxUpdateRequest))]
+[JsonSerializable(typeof(LxEmailUpdateRequest))]
+// Responses
+[JsonSerializable(typeof(LxResponse<LxBalanceData>))]
+[JsonSerializable(typeof(LxResponse<LxPriceData>))]
+[JsonSerializable(typeof(LxResponse<LxPrintJobWire>))]
+[JsonSerializable(typeof(LxResponse<LxPrintJobsData>))]
+[JsonSerializable(typeof(LxResponse<LxEmailJobWire>))]
+[JsonSerializable(typeof(LxResponse<LxEmailCreateData>))]
+[JsonSerializable(typeof(LxResponse<LxTransactionsData>))]
+[JsonSerializable(typeof(LxResponse<LxInvoicesData>))]
+[JsonSerializable(typeof(LxResponse<LxInvoiceWire>))]
+[JsonSerializable(typeof(LxResponse<JsonElement>))]
+[JsonSerializable(typeof(JsonElement))]
+// Standalone types for JsonElement.Deserialize on polymorphic e-mail responses.
+[JsonSerializable(typeof(LxEmailJobWire))]
+[JsonSerializable(typeof(LxPrintJobWire))]
+[JsonSerializable(typeof(LxEmailCreateData))]
+[JsonSerializable(typeof(LxPaginationWire))]
+// WICHTIG: snake_case-Namenskonvention (base64_file, email_receiver, dispatch_date …).
+// WhenWritingNull, damit optionale Felder weggelassen werden.
+// AllowReadingFromString, falls die API numerische Werte als Strings liefert.
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    NumberHandling = JsonNumberHandling.AllowReadingFromString)]
+internal partial class LetterXpressJsonContext : JsonSerializerContext;

--- a/src/Parcel.NET.LetterXpress.Letters/LetterXpressClient.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/LetterXpressClient.cs
@@ -1,0 +1,836 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Options;
+using Parcel.NET.LetterXpress.Internal;
+using Parcel.NET.LetterXpress.Letters.Internal;
+using Parcel.NET.LetterXpress.Letters.Models;
+
+namespace Parcel.NET.LetterXpress.Letters;
+
+/// <summary>
+/// LetterXpress (A&amp;O Fischer) API v3 client implementing <see cref="ILetterXpressClient"/>.
+/// </summary>
+public class LetterXpressClient : ILetterXpressClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly LetterXpressOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LetterXpressClient"/>.
+    /// </summary>
+    /// <param name="httpClient">The configured HTTP client for LetterXpress API requests.</param>
+    /// <param name="options">LetterXpress configuration options.</param>
+    public LetterXpressClient(HttpClient httpClient, IOptions<LetterXpressOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        _httpClient = httpClient;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task<Balance> GetBalanceAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await SendAsync(
+            HttpMethod.Get, "balance", AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxBalanceData, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress balance response contained no data.");
+        return new Balance { Amount = data.Balance, Currency = data.Currency };
+    }
+
+    /// <inheritdoc />
+    public async Task<PriceResult> GetPriceAsync(PriceRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Pages <= 0)
+        {
+            throw new ArgumentException("Price requests require a positive page count.", nameof(request));
+        }
+
+        if (request.Shipping == ShippingType.Auto)
+        {
+            throw new ArgumentException(
+                "Price requests support only National or International shipping, not Auto.", nameof(request));
+        }
+
+        if (request.Registered != RegisteredMail.None && request.Shipping == ShippingType.International)
+        {
+            throw new ArgumentException(
+                "Registered mail can only be sent nationally.", nameof(request));
+        }
+
+        var payload = new LxPriceRequest
+        {
+            Auth = BuildAuth(),
+            Letter = new LxPriceLetterWire
+            {
+                Specification = new LxSpecificationWire
+                {
+                    Pages = request.Pages,
+                    Color = ColorToWire(request.Color),
+                    Mode = ModeToWire(request.Mode),
+                    Shipping = ShippingToWire(request.Shipping),
+                    C4 = request.C4 ? 1 : 0,
+                    EmailOption = request.EmailOption is { } eo ? EmailOptionToWire(eo) : null
+                },
+                Registered = RegisteredToWire(request.Registered)
+            }
+        };
+
+        var response = await SendAsync(
+            HttpMethod.Get, "price",
+            JsonContent.Create(payload, LetterXpressJsonContext.Default.LxPriceRequest),
+            LetterXpressJsonContext.Default.LxResponseLxPriceData, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress price response contained no data.");
+        var spec = data.Letter?.Specification;
+        return new PriceResult
+        {
+            Price = data.Price,
+            Pages = spec?.Pages,
+            Color = spec?.Color,
+            Mode = spec?.Mode,
+            Shipping = spec?.Shipping
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<PrintJob>> ListPrintJobsAsync(
+        PrintJobFilter? filter = null, int? page = null, CancellationToken cancellationToken = default)
+    {
+        var url = BuildListUrl("printjobs", filter is { } f ? PrintJobFilterToWire(f) : null, page);
+
+        var response = await SendAsync(
+            HttpMethod.Get, url, AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxPrintJobsData, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data;
+        return new PagedResult<PrintJob>
+        {
+            Items = data?.PrintJobs?.Select(MapPrintJob).ToList() ?? [],
+            Pagination = MapPagination(data?.Pagination)
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<PrintJob> CreatePrintJobAsync(LetterRequest request, CancellationToken cancellationToken = default)
+    {
+        ValidateLetterRequest(request);
+
+        var payload = new LxLetterRequest { Auth = BuildAuth(), Letter = BuildLetterWire(request) };
+
+        var response = await SendAsync(
+            HttpMethod.Post, "printjobs",
+            JsonContent.Create(payload, LetterXpressJsonContext.Default.LxLetterRequest),
+            LetterXpressJsonContext.Default.LxResponseLxPrintJobWire, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress print job response contained no data.");
+        return MapPrintJob(data);
+    }
+
+    /// <inheritdoc />
+    public async Task<PrintJob> GetPrintJobAsync(long id, CancellationToken cancellationToken = default)
+    {
+        var response = await SendAsync(
+            HttpMethod.Get, $"printjobs/{id}", AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxPrintJobWire, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress print job response contained no data.");
+        return MapPrintJob(data);
+    }
+
+    /// <inheritdoc />
+    public async Task<PrintJob> UpdatePrintJobAsync(long id, PrintJobUpdate update, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        LxSpecificationWire? spec = null;
+        if (update.Color is not null || update.Mode is not null || update.Shipping is not null || update.C4 is not null)
+        {
+            spec = new LxSpecificationWire
+            {
+                Color = update.Color is { } c ? ColorToWire(c) : null,
+                Mode = update.Mode is { } m ? ModeToWire(m) : null,
+                Shipping = update.Shipping is { } s ? ShippingToWire(s) : null,
+                C4 = update.C4 is { } c4 ? (c4 ? 1 : 0) : null
+            };
+        }
+
+        var payload = new LxUpdateRequest
+        {
+            Auth = BuildAuth(),
+            Letter = new LxUpdateLetterWire
+            {
+                DispatchDate = update.DispatchDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                Registered = update.Registered is { } r ? RegisteredToWire(r) : null,
+                Notice = update.Notice,
+                Specification = spec
+            }
+        };
+
+        var response = await SendAsync(
+            HttpMethod.Put, $"printjobs/{id}",
+            JsonContent.Create(payload, LetterXpressJsonContext.Default.LxUpdateRequest),
+            LetterXpressJsonContext.Default.LxResponseLxPrintJobWire, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress print job response contained no data.");
+        return MapPrintJob(data);
+    }
+
+    /// <inheritdoc />
+    public async Task DeletePrintJobAsync(long id, CancellationToken cancellationToken = default)
+    {
+        await SendAsync(
+            HttpMethod.Delete, $"printjobs/{id}", AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseJsonElement, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<EmailJobResult> CreateEmailJobAsync(LetterRequest request, CancellationToken cancellationToken = default)
+    {
+        ValidateLetterRequest(request);
+
+        var payload = new LxLetterRequest { Auth = BuildAuth(), Letter = BuildLetterWire(request) };
+
+        var response = await SendAsync(
+            HttpMethod.Post, "emailjobs",
+            JsonContent.Create(payload, LetterXpressJsonContext.Default.LxLetterRequest),
+            LetterXpressJsonContext.Default.LxResponseJsonElement, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return ParseEmailCreate(response.Data);
+        }
+        catch (JsonException ex)
+        {
+            throw new LetterXpressException(
+                "Failed to parse LetterXpress e-mail job response.", null, null, RawTextOrNull(response.Data), ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<EmailJob> GetEmailJobAsync(long id, CancellationToken cancellationToken = default)
+    {
+        var response = await SendAsync(
+            HttpMethod.Get, $"emailjobs/{id}", AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxEmailJobWire, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress e-mail job response contained no data.");
+        return MapEmailJob(data);
+    }
+
+    /// <inheritdoc />
+    public async Task<EmailJob> UpdateEmailJobAsync(long id, string emailReceiver, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(emailReceiver);
+
+        var payload = new LxEmailUpdateRequest
+        {
+            Auth = BuildAuth(),
+            Email = new LxEmailWire { EmailReceiver = emailReceiver }
+        };
+
+        var response = await SendAsync(
+            HttpMethod.Put, $"emailjobs/{id}",
+            JsonContent.Create(payload, LetterXpressJsonContext.Default.LxEmailUpdateRequest),
+            LetterXpressJsonContext.Default.LxResponseLxEmailJobWire, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress e-mail job response contained no data.");
+        return MapEmailJob(data);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteEmailJobAsync(long id, CancellationToken cancellationToken = default)
+    {
+        await SendAsync(
+            HttpMethod.Delete, $"emailjobs/{id}", AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseJsonElement, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<EmailJob>> ListEmailJobsAsync(
+        EmailJobFilter? filter = null, int? page = null, CancellationToken cancellationToken = default)
+    {
+        var url = BuildListUrl("emailjobs", filter is { } f ? EmailJobFilterToWire(f) : null, page);
+
+        var response = await SendAsync(
+            HttpMethod.Get, url, AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseJsonElement, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return ParseEmailList(response.Data);
+        }
+        catch (JsonException ex)
+        {
+            throw new LetterXpressException(
+                "Failed to parse LetterXpress e-mail job list response.", null, null, RawTextOrNull(response.Data), ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<Transaction>> ListTransactionsAsync(
+        TransactionFilter? filter = null, int? page = null, CancellationToken cancellationToken = default)
+    {
+        var url = BuildListUrl("transactions", filter is { } f ? TransactionFilterToWire(f) : null, page);
+
+        var response = await SendAsync(
+            HttpMethod.Get, url, AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxTransactionsData, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data;
+        return new PagedResult<Transaction>
+        {
+            Items = data?.Transactions?.Select(MapTransaction).ToList() ?? [],
+            Pagination = MapPagination(data?.Pagination)
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<Invoice>> ListInvoicesAsync(int? page = null, CancellationToken cancellationToken = default)
+    {
+        var url = BuildListUrl("invoices", null, page);
+
+        var response = await SendAsync(
+            HttpMethod.Get, url, AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxInvoicesData, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data;
+        return new PagedResult<Invoice>
+        {
+            Items = data?.Invoices?.Select(MapInvoice).ToList() ?? [],
+            Pagination = MapPagination(data?.Pagination)
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<Invoice> GetInvoiceAsync(long id, CancellationToken cancellationToken = default)
+    {
+        var response = await SendAsync(
+            HttpMethod.Get, $"invoices/{id}", AuthBody(),
+            LetterXpressJsonContext.Default.LxResponseLxInvoiceWire, cancellationToken).ConfigureAwait(false);
+
+        var data = response.Data ?? throw new LetterXpressException("LetterXpress invoice response contained no data.");
+        return MapInvoice(data);
+    }
+
+    // ---- HTTP plumbing --------------------------------------------------
+
+    private LxAuth BuildAuth() => new()
+    {
+        Username = _options.Username,
+        ApiKey = _options.ApiKey,
+        Mode = _options.Mode
+    };
+
+    private HttpContent AuthBody() =>
+        JsonContent.Create(new LxAuthRequest { Auth = BuildAuth() }, LetterXpressJsonContext.Default.LxAuthRequest);
+
+    private async Task<LxResponse<TData>> SendAsync<TData>(
+        HttpMethod method,
+        string url,
+        HttpContent content,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<LxResponse<TData>> responseInfo,
+        CancellationToken cancellationToken)
+    {
+        // LetterXpress requires the Content-Type to be exactly "application/json".
+        // JsonContent/StringContent would otherwise append "; charset=utf-8", which the API rejects with HTTP 400.
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        using var request = new HttpRequestMessage(method, url) { Content = content };
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        var rawBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var detail = LetterXpressErrorHelper.TryParseErrorDetail(rawBody);
+            throw new LetterXpressException(
+                $"LetterXpress API returned {(int)response.StatusCode}: {detail}",
+                response.StatusCode,
+                ((int)response.StatusCode).ToString(),
+                rawBody);
+        }
+
+        LxResponse<TData>? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize(rawBody, responseInfo);
+        }
+        catch (JsonException ex)
+        {
+            throw new LetterXpressException(
+                "Failed to deserialize LetterXpress response.", null, null, rawBody, ex);
+        }
+
+        if (parsed is null)
+        {
+            throw new LetterXpressException(
+                "LetterXpress response was empty.", null, null, rawBody);
+        }
+
+        // The API also reports application-level errors via the body "status" field,
+        // which mirrors the documented HTTP status codes (400/401/403/...).
+        if (parsed.Status is not 0 and not 200)
+        {
+            var statusCode = Enum.IsDefined(typeof(HttpStatusCode), parsed.Status)
+                ? (HttpStatusCode?)parsed.Status
+                : null;
+            throw new LetterXpressException(
+                $"LetterXpress API returned status {parsed.Status}: {parsed.Message}",
+                statusCode,
+                parsed.Status.ToString(CultureInfo.InvariantCulture),
+                rawBody);
+        }
+
+        return parsed;
+    }
+
+    private static string BuildListUrl(string path, string? filter, int? page)
+    {
+        var query = new List<string>();
+        if (filter is not null) query.Add($"filter={Uri.EscapeDataString(filter)}");
+        if (page is { } p) query.Add($"page={p.ToString(CultureInfo.InvariantCulture)}");
+        return query.Count == 0 ? path : $"{path}?{string.Join('&', query)}";
+    }
+
+    // ---- Request building -----------------------------------------------
+
+    // The API accepts at most 50 MB per PDF / request.
+    private const long MaxFileBytes = 50L * 1024 * 1024;
+
+    private static void ValidateLetterRequest(LetterRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.File);
+        ArgumentNullException.ThrowIfNull(request.Specification);
+
+        if (request.File.Length == 0)
+        {
+            throw new ArgumentException("The letter file must not be empty.", nameof(request));
+        }
+
+        // The 50 MB limit applies per request, so count the main file plus all secondary PDFs.
+        long totalBytes = request.File.LongLength;
+        if (request.Attachments is { } attachments)
+        {
+            totalBytes += attachments.Where(a => a is not null).Sum(a => a.LongLength);
+        }
+        if (request.Backgrounds is { } bg)
+        {
+            totalBytes += (bg.FirstPage?.LongLength ?? 0) + (bg.OtherPages?.LongLength ?? 0);
+        }
+        if (request.TermsAndConditions?.Terms is { } terms)
+        {
+            totalBytes += terms.LongLength;
+        }
+
+        if (totalBytes > MaxFileBytes)
+        {
+            throw new ArgumentException(
+                $"The request exceeds the {MaxFileBytes / (1024 * 1024)} MB limit (PDFs total {totalBytes} bytes).",
+                nameof(request));
+        }
+
+        // Per the spec, a serial letter cannot be combined with an email_letter object.
+        if (request.SerialLetter is not null && request.EmailLetter is not null)
+        {
+            throw new ArgumentException(
+                "SerialLetter and EmailLetter cannot be combined in a single request.", nameof(request));
+        }
+
+        // A numeric serial separator must actually be a positive whole number, otherwise the wire
+        // shape (pages_separator_type = "number") would carry a string value, violating the spec.
+        if (request.SerialLetter is { PagesSeparatorType: SeparatorType.Number } serial
+            && (!long.TryParse(serial.PagesSeparatorValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var pages) || pages <= 0))
+        {
+            throw new ArgumentException(
+                "SerialLetter.PagesSeparatorValue must be a positive whole number when PagesSeparatorType is Number.",
+                nameof(request));
+        }
+
+        // Registered mail can only be sent nationally.
+        if (request.Registered != RegisteredMail.None && request.Specification.Shipping == ShippingType.International)
+        {
+            throw new ArgumentException(
+                "Registered mail can only be sent nationally.", nameof(request));
+        }
+
+        // The dispatch date, if set, must not be in the past (the server enforces "in the future").
+        if (request.DispatchDate is { } dispatch && dispatch < DateOnly.FromDateTime(DateTime.UtcNow))
+        {
+            throw new ArgumentException("DispatchDate must not be in the past.", nameof(request));
+        }
+    }
+
+    private static LxLetterWire BuildLetterWire(LetterRequest request)
+    {
+        var (base64File, checksum) = EncodeFile(request.File);
+        var spec = request.Specification;
+
+        var wire = new LxLetterWire
+        {
+            Base64File = base64File,
+            Base64FileChecksum = checksum,
+            Specification = new LxSpecificationWire
+            {
+                Color = ColorToWire(spec.Color),
+                Mode = ModeToWire(spec.Mode),
+                Shipping = ShippingToWire(spec.Shipping),
+                C4 = spec.C4 ? 1 : 0
+            },
+            FilenameOriginal = request.FilenameOriginal,
+            Registered = RegisteredToWire(request.Registered),
+            DispatchDate = request.DispatchDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            Notice = request.Notice
+        };
+
+        if (request.SerialLetter is { } sl)
+        {
+            // For separator type "number" the API expects a JSON number, otherwise a JSON string (keyword).
+            JsonNode separatorValue =
+                sl.PagesSeparatorType == SeparatorType.Number
+                && long.TryParse(sl.PagesSeparatorValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var pageCount)
+                    ? JsonValue.Create(pageCount)
+                    : JsonValue.Create(sl.PagesSeparatorValue);
+
+            wire.SerialLetter = new LxSerialWire
+            {
+                PagesSeparatorType = SeparatorTypeToWire(sl.PagesSeparatorType),
+                PagesSeparatorValue = separatorValue
+            };
+        }
+
+        if (request.EmailLetter is { } el)
+        {
+            wire.EmailLetter = new LxEmailLetterWire
+            {
+                EmailOption = EmailOptionToWire(el.EmailOption),
+                EmailReceiver = el.EmailReceiver
+            };
+        }
+
+        if (request.Attachments is { Count: > 0 } attachments)
+        {
+            wire.Base64Attachments = attachments.Select(Convert.ToBase64String).ToList();
+        }
+
+        if (request.Backgrounds is { } bg)
+        {
+            wire.Backgrounds = new LxBackgroundsWire
+            {
+                Base64BackgroundFirstPage = bg.FirstPage is null ? null : Convert.ToBase64String(bg.FirstPage),
+                Base64BackgroundOtherPages = bg.OtherPages is null ? null : Convert.ToBase64String(bg.OtherPages)
+            };
+        }
+
+        if (request.TermsAndConditions is { } tc)
+        {
+            wire.TermsAndConditions = new LxTermsWire
+            {
+                Base64Terms = Convert.ToBase64String(tc.Terms),
+                TermsOnAllPages = tc.OnAllPages ? 1 : 0
+            };
+        }
+
+        if (request.BankForm is { } bf)
+        {
+            wire.BankForm = new LxBankFormWire
+            {
+                BankFormIncluded = bf.Included ? 1 : 0,
+                Payee = bf.Payee,
+                Iban = bf.Iban,
+                Bic = bf.Bic,
+                Amount = bf.Amount,
+                PurposeOfPayment = bf.PurposeOfPayment,
+                PurposeOfPayment2 = bf.PurposeOfPayment2
+            };
+        }
+
+        return wire;
+    }
+
+    internal static (string Base64File, string Checksum) EncodeFile(byte[] file)
+    {
+        var base64File = Convert.ToBase64String(file);
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(base64File));
+        var checksum = Convert.ToHexString(hash).ToLowerInvariant();
+        return (base64File, checksum);
+    }
+
+    // ---- Response mapping -----------------------------------------------
+
+    private EmailJobResult ParseEmailCreate(JsonElement data)
+    {
+        if (data.ValueKind == JsonValueKind.Array)
+        {
+            return new EmailJobResult { EmailJobs = DeserializeEmailJobs(data) };
+        }
+
+        if (data.ValueKind == JsonValueKind.Object && data.TryGetProperty("emailjobs", out _))
+        {
+            var combined = data.Deserialize(LetterXpressJsonContext.Default.LxEmailCreateData);
+            return new EmailJobResult
+            {
+                EmailJobs = combined?.EmailJobs?.Select(MapEmailJob).ToList() ?? [],
+                PrintJobs = combined?.PrintJobs?.Select(MapPrintJob).ToList() ?? []
+            };
+        }
+
+        if (data.ValueKind == JsonValueKind.Object)
+        {
+            var single = data.Deserialize(LetterXpressJsonContext.Default.LxEmailJobWire);
+            return new EmailJobResult { EmailJobs = single is null ? [] : [MapEmailJob(single)] };
+        }
+
+        return new EmailJobResult();
+    }
+
+    private PagedResult<EmailJob> ParseEmailList(JsonElement data)
+    {
+        if (data.ValueKind == JsonValueKind.Array)
+        {
+            return new PagedResult<EmailJob> { Items = DeserializeEmailJobs(data) };
+        }
+
+        if (data.ValueKind != JsonValueKind.Object)
+        {
+            return new PagedResult<EmailJob>();
+        }
+
+        Pagination? pagination = null;
+        if (data.TryGetProperty("pagination", out var paginationElement))
+        {
+            pagination = MapPagination(paginationElement.Deserialize(LetterXpressJsonContext.Default.LxPaginationWire));
+        }
+
+        var jobs = new List<EmailJob>();
+        if (data.TryGetProperty("emailjobs", out var emailJobsElement) && emailJobsElement.ValueKind == JsonValueKind.Array)
+        {
+            jobs = DeserializeEmailJobs(emailJobsElement);
+        }
+        else if (data.TryGetProperty("id", out _))
+        {
+            // Defensive: a single e-mail job object without an explicit array wrapper.
+            var single = data.Deserialize(LetterXpressJsonContext.Default.LxEmailJobWire);
+            if (single is not null) jobs.Add(MapEmailJob(single));
+        }
+
+        return new PagedResult<EmailJob> { Items = jobs, Pagination = pagination };
+    }
+
+    private static string? RawTextOrNull(JsonElement element) =>
+        element.ValueKind == JsonValueKind.Undefined ? null : element.GetRawText();
+
+    private List<EmailJob> DeserializeEmailJobs(JsonElement array)
+    {
+        var jobs = new List<EmailJob>();
+        foreach (var element in array.EnumerateArray())
+        {
+            var wire = element.Deserialize(LetterXpressJsonContext.Default.LxEmailJobWire);
+            if (wire is not null) jobs.Add(MapEmailJob(wire));
+        }
+        return jobs;
+    }
+
+    private static PrintJob MapPrintJob(LxPrintJobWire w) => new()
+    {
+        Id = w.Id,
+        Shipping = w.Shipping,
+        Mode = w.Mode,
+        Color = w.Color,
+        C4 = w.C4 != 0,
+        Registered = w.Registered,
+        BankForm = w.BankForm != 0,
+        Notice = w.Notice,
+        Status = w.Status,
+        DispatchDate = w.DispatchDate,
+        FilenameOriginal = w.FilenameOriginal,
+        CreatedAt = ParseDateTime(w.CreatedAt),
+        UpdatedAt = ParseDateTime(w.UpdatedAt),
+        Items = w.Items?.Select(MapPrintJobItem).ToList() ?? []
+    };
+
+    private static PrintJobItem MapPrintJobItem(LxPrintJobItemWire w) => new()
+    {
+        Address = w.Address,
+        Pages = w.Pages,
+        Amount = w.Amount,
+        Vat = w.Vat,
+        Status = w.Status,
+        TrackingCode = w.TrackingCode,
+        Base64Data = w.Base64Data
+    };
+
+    private static EmailJob MapEmailJob(LxEmailJobWire w) => new()
+    {
+        Id = w.Id,
+        EmailSender = w.EmailSender,
+        EmailReceiver = w.EmailReceiver,
+        EmailOption = w.EmailOption,
+        SentAt = ParseDateTime(w.SentAt),
+        Amount = w.Amount,
+        Vat = w.Vat,
+        Status = w.Status,
+        Subject = w.Subject,
+        Content = w.Content,
+        Footer = w.Footer,
+        CreatedAt = ParseDateTime(w.CreatedAt),
+        PrintJobId = w.PrintjobId,
+        PrintJob = w.Printjob is null ? null : MapPrintJob(w.Printjob)
+    };
+
+    private static Transaction MapTransaction(LxTransactionWire w) => new()
+    {
+        Amount = w.Amount,
+        Currency = w.Currency,
+        Description = w.Description,
+        CreatedAt = ParseDateTime(w.CreatedAt)
+    };
+
+    private static Invoice MapInvoice(LxInvoiceWire w) => new()
+    {
+        Id = w.Id,
+        Amount = w.Amount,
+        Vat = w.Vat,
+        InvoiceDate = ParseDate(w.InvoiceDate),
+        Base64Data = w.Base64Data
+    };
+
+    private static Pagination? MapPagination(LxPaginationWire? w) => w is null ? null : new Pagination
+    {
+        Total = w.Total,
+        Count = w.Count,
+        CurrentPage = w.CurrentPage,
+        LastPage = w.LastPage,
+        PerPage = w.PerPage,
+        FirstPageUrl = w.FirstPageUrl,
+        LastPageUrl = w.LastPageUrl,
+        NextPageUrl = w.NextPageUrl,
+        PrevPageUrl = w.PrevPageUrl
+    };
+
+    // LetterXpress returns timestamps without a timezone designator, in German local time
+    // (Europe/Berlin, i.e. CET/CEST). Verified against the live API.
+    private static readonly TimeZoneInfo? BerlinTimeZone = ResolveBerlinTimeZone();
+
+    private static TimeZoneInfo? ResolveBerlinTimeZone()
+    {
+        foreach (var id in (string[])["Europe/Berlin", "W. Europe Standard Time"])
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                // Try the next identifier.
+            }
+            catch (InvalidTimeZoneException)
+            {
+                // Try the next identifier.
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? ParseDateTime(string? value)
+    {
+        if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            return null;
+        }
+
+        var unspecified = DateTime.SpecifyKind(parsed, DateTimeKind.Unspecified);
+        var offset = BerlinTimeZone?.GetUtcOffset(unspecified) ?? TimeSpan.Zero;
+        return new DateTimeOffset(unspecified, offset);
+    }
+
+    private static DateOnly? ParseDate(string? value) =>
+        DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed
+            : null;
+
+    // ---- Enum mapping ---------------------------------------------------
+
+    private static string ColorToWire(LetterColor color) => color switch
+    {
+        LetterColor.BlackWhite => "1",
+        LetterColor.Color => "4",
+        _ => "1"
+    };
+
+    private static string ModeToWire(PrintMode mode) => mode switch
+    {
+        PrintMode.Simplex => "simplex",
+        PrintMode.Duplex => "duplex",
+        _ => "simplex"
+    };
+
+    private static string ShippingToWire(ShippingType shipping) => shipping switch
+    {
+        ShippingType.National => "national",
+        ShippingType.International => "international",
+        ShippingType.Auto => "auto",
+        _ => "auto"
+    };
+
+    private static string? RegisteredToWire(RegisteredMail registered) => registered switch
+    {
+        RegisteredMail.EinschreibenEinwurf => "r1",
+        RegisteredMail.Einschreiben => "r2",
+        _ => null
+    };
+
+    private static string EmailOptionToWire(EmailOption option) => option switch
+    {
+        EmailOption.MailDirect => "maildirect",
+        EmailOption.MailPlus => "mailplus",
+        EmailOption.MailSecure => "mailsecure",
+        _ => "maildirect"
+    };
+
+    private static string SeparatorTypeToWire(SeparatorType type) => type switch
+    {
+        SeparatorType.String => "string",
+        SeparatorType.Number => "number",
+        _ => "string"
+    };
+
+    private static string PrintJobFilterToWire(PrintJobFilter filter) => filter switch
+    {
+        PrintJobFilter.Queue => "queue",
+        PrintJobFilter.Hold => "hold",
+        PrintJobFilter.Done => "done",
+        PrintJobFilter.Canceled => "canceled",
+        PrintJobFilter.Draft => "draft",
+        _ => "queue"
+    };
+
+    private static string EmailJobFilterToWire(EmailJobFilter filter) => filter switch
+    {
+        EmailJobFilter.Queue => "queue",
+        EmailJobFilter.Hold => "hold",
+        EmailJobFilter.Canceled => "canceled",
+        EmailJobFilter.Draft => "draft",
+        EmailJobFilter.Success => "success",
+        _ => "queue"
+    };
+
+    private static string TransactionFilterToWire(TransactionFilter filter) => filter switch
+    {
+        TransactionFilter.PayIns => "payins",
+        TransactionFilter.PayOuts => "payouts",
+        TransactionFilter.PrintJobs => "printjobs",
+        _ => "payins"
+    };
+}

--- a/src/Parcel.NET.LetterXpress.Letters/LetterXpressLettersExtensions.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/LetterXpressLettersExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Parcel.NET.LetterXpress.Letters;
+
+/// <summary>
+/// Extension methods for registering the LetterXpress letters client.
+/// </summary>
+public static class LetterXpressLettersExtensions
+{
+    /// <summary>
+    /// Adds the LetterXpress letters client to the service collection, registered as
+    /// <see cref="ILetterXpressClient"/>.
+    /// </summary>
+    /// <param name="builder">The LetterXpress builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static LetterXpressBuilder AddLetterXpressLetters(this LetterXpressBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddHttpClient<LetterXpressClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<LetterXpressOptions>>().Value;
+            client.BaseAddress = new Uri(options.BaseUrl);
+        });
+
+        builder.Services.AddTransient<ILetterXpressClient>(sp => sp.GetRequiredService<LetterXpressClient>());
+
+        return builder;
+    }
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/AccountModels.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/AccountModels.cs
@@ -1,0 +1,155 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// Account balance.
+/// </summary>
+public class Balance
+{
+    /// <summary>
+    /// Gets the current balance.
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets the currency (e.g. <c>EUR</c>).
+    /// </summary>
+    public string? Currency { get; init; }
+}
+
+/// <summary>
+/// Result of a price calculation.
+/// </summary>
+public class PriceResult
+{
+    /// <summary>
+    /// Gets the calculated gross price.
+    /// </summary>
+    public decimal Price { get; init; }
+
+    /// <summary>
+    /// Gets the number of pages the price was calculated for.
+    /// </summary>
+    public int? Pages { get; init; }
+
+    /// <summary>
+    /// Gets the print color the price was calculated for.
+    /// </summary>
+    public string? Color { get; init; }
+
+    /// <summary>
+    /// Gets the print mode the price was calculated for.
+    /// </summary>
+    public string? Mode { get; init; }
+
+    /// <summary>
+    /// Gets the shipping destination the price was calculated for.
+    /// </summary>
+    public string? Shipping { get; init; }
+}
+
+/// <summary>
+/// An account transaction.
+/// </summary>
+public class Transaction
+{
+    /// <summary>
+    /// Gets the amount (negative for charges, positive for top-ups).
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets the currency (e.g. <c>EUR</c>).
+    /// </summary>
+    public string? Currency { get; init; }
+
+    /// <summary>
+    /// Gets the description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the creation timestamp.
+    /// </summary>
+    public DateTimeOffset? CreatedAt { get; init; }
+}
+
+/// <summary>
+/// An invoice.
+/// </summary>
+public class Invoice
+{
+    /// <summary>
+    /// Gets the invoice ID.
+    /// </summary>
+    public long Id { get; init; }
+
+    /// <summary>
+    /// Gets the net amount.
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets the VAT.
+    /// </summary>
+    public decimal Vat { get; init; }
+
+    /// <summary>
+    /// Gets the invoice date.
+    /// </summary>
+    public DateOnly? InvoiceDate { get; init; }
+
+    /// <summary>
+    /// Gets the invoice PDF as base64, returned only when retrieving a single invoice.
+    /// </summary>
+    public string? Base64Data { get; init; }
+}
+
+/// <summary>
+/// Pagination metadata returned by list endpoints.
+/// </summary>
+public class Pagination
+{
+    /// <summary>Gets the total number of items.</summary>
+    public int Total { get; init; }
+
+    /// <summary>Gets the number of items on the current page.</summary>
+    public int Count { get; init; }
+
+    /// <summary>Gets the current page number.</summary>
+    public int CurrentPage { get; init; }
+
+    /// <summary>Gets the last page number.</summary>
+    public int LastPage { get; init; }
+
+    /// <summary>Gets the number of items per page.</summary>
+    public int PerPage { get; init; }
+
+    /// <summary>Gets the URL of the first page, if any.</summary>
+    public string? FirstPageUrl { get; init; }
+
+    /// <summary>Gets the URL of the last page, if any.</summary>
+    public string? LastPageUrl { get; init; }
+
+    /// <summary>Gets the URL of the next page, if any.</summary>
+    public string? NextPageUrl { get; init; }
+
+    /// <summary>Gets the URL of the previous page, if any.</summary>
+    public string? PrevPageUrl { get; init; }
+}
+
+/// <summary>
+/// A paged list result.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+public class PagedResult<T>
+{
+    /// <summary>
+    /// Gets the items on the current page.
+    /// </summary>
+    public IReadOnlyList<T> Items { get; init; } = [];
+
+    /// <summary>
+    /// Gets the pagination metadata, if available.
+    /// </summary>
+    public Pagination? Pagination { get; init; }
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/EmailJob.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/EmailJob.cs
@@ -1,0 +1,94 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// A LetterXpress SMART@MAIL e-mail job.
+/// </summary>
+public class EmailJob
+{
+    /// <summary>
+    /// Gets the e-mail job ID.
+    /// </summary>
+    public long Id { get; init; }
+
+    /// <summary>
+    /// Gets the sender e-mail address.
+    /// </summary>
+    public string? EmailSender { get; init; }
+
+    /// <summary>
+    /// Gets the recipient e-mail address.
+    /// </summary>
+    public string? EmailReceiver { get; init; }
+
+    /// <summary>
+    /// Gets the SMART@MAIL option (<c>maildirect</c>, <c>mailplus</c>, <c>mailsecure</c>).
+    /// </summary>
+    public string? EmailOption { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp the e-mail was sent, if available.
+    /// </summary>
+    public DateTimeOffset? SentAt { get; init; }
+
+    /// <summary>
+    /// Gets the net amount charged.
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets the VAT.
+    /// </summary>
+    public decimal Vat { get; init; }
+
+    /// <summary>
+    /// Gets the job status (e.g. <c>queue</c>, <c>hold</c>, <c>success</c>).
+    /// </summary>
+    public string? Status { get; init; }
+
+    /// <summary>
+    /// Gets the e-mail subject.
+    /// </summary>
+    public string? Subject { get; init; }
+
+    /// <summary>
+    /// Gets the e-mail content.
+    /// </summary>
+    public string? Content { get; init; }
+
+    /// <summary>
+    /// Gets the e-mail footer.
+    /// </summary>
+    public string? Footer { get; init; }
+
+    /// <summary>
+    /// Gets the creation timestamp.
+    /// </summary>
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    /// <summary>
+    /// Gets the ID of the associated print job, when the e-mail job is part of a serial response.
+    /// </summary>
+    public long? PrintJobId { get; init; }
+
+    /// <summary>
+    /// Gets the associated print job, returned for MailPlus jobs.
+    /// </summary>
+    public PrintJob? PrintJob { get; init; }
+}
+
+/// <summary>
+/// Result of submitting an e-mail job. Depending on the request this contains a single e-mail job,
+/// multiple e-mail jobs (serial processing), and/or print jobs created for pages without a white code.
+/// </summary>
+public class EmailJobResult
+{
+    /// <summary>
+    /// Gets the created e-mail jobs.
+    /// </summary>
+    public IReadOnlyList<EmailJob> EmailJobs { get; init; } = [];
+
+    /// <summary>
+    /// Gets any print jobs created alongside the e-mail jobs (e.g. for MailPlus or pages without a white code).
+    /// </summary>
+    public IReadOnlyList<PrintJob> PrintJobs { get; init; } = [];
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/Enums.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/Enums.cs
@@ -1,0 +1,140 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// Print color of a letter.
+/// </summary>
+public enum LetterColor
+{
+    /// <summary>Black/white printing (API value <c>"1"</c>).</summary>
+    BlackWhite,
+
+    /// <summary>Color printing (API value <c>"4"</c>).</summary>
+    Color
+}
+
+/// <summary>
+/// Print mode of a letter.
+/// </summary>
+public enum PrintMode
+{
+    /// <summary>Single-sided printing (API value <c>"simplex"</c>).</summary>
+    Simplex,
+
+    /// <summary>Double-sided printing (API value <c>"duplex"</c>).</summary>
+    Duplex
+}
+
+/// <summary>
+/// Shipping destination of a letter.
+/// </summary>
+public enum ShippingType
+{
+    /// <summary>National shipping (API value <c>"national"</c>).</summary>
+    National,
+
+    /// <summary>International shipping (API value <c>"international"</c>).</summary>
+    International,
+
+    /// <summary>Automatic detection (API value <c>"auto"</c>). Not valid for price requests.</summary>
+    Auto
+}
+
+/// <summary>
+/// Registered mail option. Registered mail can only be sent nationally.
+/// </summary>
+public enum RegisteredMail
+{
+    /// <summary>No registered mail.</summary>
+    None,
+
+    /// <summary>Einschreiben Einwurf (API value <c>"r1"</c>).</summary>
+    EinschreibenEinwurf,
+
+    /// <summary>Einschreiben (API value <c>"r2"</c>).</summary>
+    Einschreiben
+}
+
+/// <summary>
+/// LXP SMART@MAIL e-mail delivery option.
+/// </summary>
+public enum EmailOption
+{
+    /// <summary>maildirect.</summary>
+    MailDirect,
+
+    /// <summary>mailplus.</summary>
+    MailPlus,
+
+    /// <summary>mailsecure.</summary>
+    MailSecure
+}
+
+/// <summary>
+/// Type of the serial letter page separator.
+/// </summary>
+public enum SeparatorType
+{
+    /// <summary>A keyword string is used to separate the individual letters (API value <c>"string"</c>).</summary>
+    String,
+
+    /// <summary>A fixed number of pages is used to separate the individual letters (API value <c>"number"</c>).</summary>
+    Number
+}
+
+/// <summary>
+/// Filter for listing print jobs.
+/// </summary>
+public enum PrintJobFilter
+{
+    /// <summary>Jobs in the queue.</summary>
+    Queue,
+
+    /// <summary>Held jobs.</summary>
+    Hold,
+
+    /// <summary>Processed jobs.</summary>
+    Done,
+
+    /// <summary>Cancelled jobs.</summary>
+    Canceled,
+
+    /// <summary>Jobs in the Postbox.</summary>
+    Draft
+}
+
+/// <summary>
+/// Filter for listing e-mail jobs. Accepted values were verified against the live API
+/// (the e-mail equivalent of the print job's <c>done</c> status is <c>success</c>).
+/// </summary>
+public enum EmailJobFilter
+{
+    /// <summary>Jobs in the queue.</summary>
+    Queue,
+
+    /// <summary>Held jobs.</summary>
+    Hold,
+
+    /// <summary>Cancelled jobs.</summary>
+    Canceled,
+
+    /// <summary>Jobs in the Postbox.</summary>
+    Draft,
+
+    /// <summary>Successfully sent jobs.</summary>
+    Success
+}
+
+/// <summary>
+/// Filter for listing transactions.
+/// </summary>
+public enum TransactionFilter
+{
+    /// <summary>Pay-ins / vouchers / kickbacks.</summary>
+    PayIns,
+
+    /// <summary>Pay-outs.</summary>
+    PayOuts,
+
+    /// <summary>Print jobs.</summary>
+    PrintJobs
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/LetterOptions.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/LetterOptions.cs
@@ -1,0 +1,112 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// Options for splitting a serial letter into individual letters.
+/// </summary>
+public class SerialLetterOptions
+{
+    /// <summary>
+    /// Gets or sets the separator type.
+    /// </summary>
+    public SeparatorType PagesSeparatorType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the separator value: a keyword when <see cref="PagesSeparatorType"/> is
+    /// <see cref="SeparatorType.String"/>, or a page count when it is <see cref="SeparatorType.Number"/>.
+    /// </summary>
+    public required string PagesSeparatorValue { get; set; }
+}
+
+/// <summary>
+/// LXP SMART@MAIL options for transmitting a single job as an e-mail letter.
+/// Cannot be combined with a serial letter.
+/// </summary>
+public class EmailLetterOptions
+{
+    /// <summary>
+    /// Gets or sets the SMART@MAIL delivery option.
+    /// </summary>
+    public EmailOption EmailOption { get; set; }
+
+    /// <summary>
+    /// Gets or sets the valid recipient e-mail address.
+    /// </summary>
+    public required string EmailReceiver { get; set; }
+}
+
+/// <summary>
+/// Background PDFs inserted behind a letter's pages. Each background must be a single-page
+/// A4 portrait (29.7 x 21.0 cm) PDF.
+/// </summary>
+public class LetterBackgrounds
+{
+    /// <summary>
+    /// Gets or sets the background PDF for the first page.
+    /// </summary>
+    public byte[]? FirstPage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the background PDF for all other pages.
+    /// </summary>
+    public byte[]? OtherPages { get; set; }
+}
+
+/// <summary>
+/// Terms and conditions PDF appended to a letter. Must be a single-page A4 portrait
+/// (29.7 x 21.0 cm) PDF. Printing is automatically double-sided.
+/// </summary>
+public class TermsAndConditions
+{
+    /// <summary>
+    /// Gets or sets the terms and conditions PDF.
+    /// </summary>
+    public required byte[] Terms { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the terms are inserted behind all pages
+    /// (<see langword="true"/>) or only behind the first page (<see langword="false"/>).
+    /// </summary>
+    public bool OnAllPages { get; set; }
+}
+
+/// <summary>
+/// Bank transfer form attached as the last sheet of a letter.
+/// </summary>
+public class BankForm
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the bank form is already included in the PDF's last sheet.
+    /// When <see langword="true"/>, the payment detail fields below are ignored and the last (blank) sheet is used.
+    /// </summary>
+    public bool Included { get; set; }
+
+    /// <summary>
+    /// Gets or sets the payee. Max. 27 characters. Ignored when <see cref="Included"/> is <see langword="true"/>.
+    /// </summary>
+    public string? Payee { get; set; }
+
+    /// <summary>
+    /// Gets or sets the IBAN. Max. 34 characters.
+    /// </summary>
+    public string? Iban { get; set; }
+
+    /// <summary>
+    /// Gets or sets the BIC. Max. 11 characters.
+    /// </summary>
+    public string? Bic { get; set; }
+
+    /// <summary>
+    /// Gets or sets the amount. Max. 12 characters.
+    /// </summary>
+    public string? Amount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the purpose of payment. Max. 27 characters.
+    /// </summary>
+    public string? PurposeOfPayment { get; set; }
+
+    /// <summary>
+    /// Gets or sets the second purpose of payment line. Max. 27 characters.
+    /// </summary>
+    public string? PurposeOfPayment2 { get; set; }
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/LetterRequest.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/LetterRequest.cs
@@ -1,0 +1,156 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// Request for submitting a letter (print job or e-mail job). The PDF is supplied as raw bytes;
+/// the client computes the base64 encoding and MD5 checksum automatically.
+/// </summary>
+public class LetterRequest
+{
+    /// <summary>
+    /// Gets or sets the letter PDF as raw bytes. Max. 50 MB.
+    /// </summary>
+    public required byte[] File { get; set; }
+
+    /// <summary>
+    /// Gets or sets the print and shipping specification.
+    /// </summary>
+    public required LetterSpecification Specification { get; set; }
+
+    /// <summary>
+    /// Gets or sets the original file name (e.g. <c>Rechnung-123456.pdf</c>).
+    /// Optional; necessary for LXP SMART@MAIL and returned when retrieving jobs.
+    /// </summary>
+    public string? FilenameOriginal { get; set; }
+
+    /// <summary>
+    /// Gets or sets the registered mail option. Registered mail can only be sent nationally.
+    /// Defaults to <see cref="RegisteredMail.None"/>.
+    /// </summary>
+    public RegisteredMail Registered { get; set; } = RegisteredMail.None;
+
+    /// <summary>
+    /// Gets or sets the dispatch date. Optional; must be in the future.
+    /// </summary>
+    public DateOnly? DispatchDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets serial letter options. Cannot be combined with <see cref="EmailLetter"/>.
+    /// </summary>
+    public SerialLetterOptions? SerialLetter { get; set; }
+
+    /// <summary>
+    /// Gets or sets LXP SMART@MAIL e-mail options for a single job. Cannot be combined with <see cref="SerialLetter"/>.
+    /// </summary>
+    public EmailLetterOptions? EmailLetter { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional attachments as raw PDF bytes. Each attachment must be A4 portrait
+    /// (29.7 x 21.0 cm). The order is preserved.
+    /// </summary>
+    public IReadOnlyList<byte[]>? Attachments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the letter background PDFs.
+    /// </summary>
+    public LetterBackgrounds? Backgrounds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the terms and conditions PDF.
+    /// </summary>
+    public TermsAndConditions? TermsAndConditions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the bank transfer form.
+    /// </summary>
+    public BankForm? BankForm { get; set; }
+
+    /// <summary>
+    /// Gets or sets an arbitrary notice stored with the job. Max. 255 characters.
+    /// </summary>
+    public string? Notice { get; set; }
+}
+
+/// <summary>
+/// Request for changing an existing print job within the first 15 minutes after submission.
+/// Only the specification and shipping options can be changed; the PDF cannot.
+/// All properties are optional — only set ones are sent.
+/// </summary>
+public class PrintJobUpdate
+{
+    /// <summary>
+    /// Gets or sets the new dispatch date.
+    /// </summary>
+    public DateOnly? DispatchDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the new registered mail option.
+    /// </summary>
+    public RegisteredMail? Registered { get; set; }
+
+    /// <summary>
+    /// Gets or sets the new notice.
+    /// </summary>
+    public string? Notice { get; set; }
+
+    /// <summary>
+    /// Gets or sets the new print color.
+    /// </summary>
+    public LetterColor? Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets the new print mode.
+    /// </summary>
+    public PrintMode? Mode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the new shipping destination.
+    /// </summary>
+    public ShippingType? Shipping { get; set; }
+
+    /// <summary>
+    /// Gets or sets the new C4 envelope flag.
+    /// </summary>
+    public bool? C4 { get; set; }
+}
+
+/// <summary>
+/// Request for a price calculation.
+/// </summary>
+public class PriceRequest
+{
+    /// <summary>
+    /// Gets or sets the number of pages.
+    /// </summary>
+    public required int Pages { get; set; }
+
+    /// <summary>
+    /// Gets or sets the print color. Defaults to <see cref="LetterColor.BlackWhite"/>.
+    /// </summary>
+    public LetterColor Color { get; set; } = LetterColor.BlackWhite;
+
+    /// <summary>
+    /// Gets or sets the print mode. Defaults to <see cref="PrintMode.Simplex"/>.
+    /// </summary>
+    public PrintMode Mode { get; set; } = PrintMode.Simplex;
+
+    /// <summary>
+    /// Gets or sets the shipping destination. Only <see cref="ShippingType.National"/> and
+    /// <see cref="ShippingType.International"/> are valid for price requests.
+    /// </summary>
+    public ShippingType Shipping { get; set; } = ShippingType.National;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use a C4 envelope.
+    /// </summary>
+    public bool C4 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SMART@MAIL e-mail option. Optional.
+    /// </summary>
+    public EmailOption? EmailOption { get; set; }
+
+    /// <summary>
+    /// Gets or sets the registered mail option. Optional; only national shipping is supported for registered mail.
+    /// </summary>
+    public RegisteredMail Registered { get; set; } = RegisteredMail.None;
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/LetterSpecification.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/LetterSpecification.cs
@@ -1,0 +1,28 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// Print and shipping specification of a letter.
+/// </summary>
+public class LetterSpecification
+{
+    /// <summary>
+    /// Gets or sets the print color. Defaults to <see cref="LetterColor.BlackWhite"/>.
+    /// </summary>
+    public LetterColor Color { get; set; } = LetterColor.BlackWhite;
+
+    /// <summary>
+    /// Gets or sets the print mode. Defaults to <see cref="PrintMode.Simplex"/>.
+    /// </summary>
+    public PrintMode Mode { get; set; } = PrintMode.Simplex;
+
+    /// <summary>
+    /// Gets or sets the shipping destination. Defaults to <see cref="ShippingType.Auto"/>.
+    /// </summary>
+    public ShippingType Shipping { get; set; } = ShippingType.Auto;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use a C4 envelope.
+    /// Optional, applies to letters under 9 sheets.
+    /// </summary>
+    public bool C4 { get; set; }
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Models/PrintJob.cs
+++ b/src/Parcel.NET.LetterXpress.Letters/Models/PrintJob.cs
@@ -1,0 +1,118 @@
+namespace Parcel.NET.LetterXpress.Letters.Models;
+
+/// <summary>
+/// A single recipient item of a print job.
+/// </summary>
+public class PrintJobItem
+{
+    /// <summary>
+    /// Gets the recipient address as a single line.
+    /// </summary>
+    public string? Address { get; init; }
+
+    /// <summary>
+    /// Gets the number of pages.
+    /// </summary>
+    public int Pages { get; init; }
+
+    /// <summary>
+    /// Gets the net amount charged for this item.
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets the VAT for this item.
+    /// </summary>
+    public decimal Vat { get; init; }
+
+    /// <summary>
+    /// Gets the item status (e.g. <c>queue</c>, <c>sent</c>).
+    /// </summary>
+    public string? Status { get; init; }
+
+    /// <summary>
+    /// Gets the registered mail tracking code, if available.
+    /// </summary>
+    public string? TrackingCode { get; init; }
+
+    /// <summary>
+    /// Gets the rendered letter PDF as base64, returned only when retrieving a single job.
+    /// </summary>
+    public string? Base64Data { get; init; }
+}
+
+/// <summary>
+/// A LetterXpress print job.
+/// </summary>
+public class PrintJob
+{
+    /// <summary>
+    /// Gets the print job ID.
+    /// </summary>
+    public long Id { get; init; }
+
+    /// <summary>
+    /// Gets the shipping destination (e.g. <c>national</c>).
+    /// </summary>
+    public string? Shipping { get; init; }
+
+    /// <summary>
+    /// Gets the print mode (e.g. <c>simplex</c>).
+    /// </summary>
+    public string? Mode { get; init; }
+
+    /// <summary>
+    /// Gets the print color (<c>1</c> for black/white, <c>4</c> for color).
+    /// </summary>
+    public string? Color { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a C4 envelope is used.
+    /// </summary>
+    public bool C4 { get; init; }
+
+    /// <summary>
+    /// Gets the registered mail option (<c>r1</c>, <c>r2</c>), if any.
+    /// </summary>
+    public string? Registered { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a bank form is attached.
+    /// </summary>
+    public bool BankForm { get; init; }
+
+    /// <summary>
+    /// Gets the notice stored with the job.
+    /// </summary>
+    public string? Notice { get; init; }
+
+    /// <summary>
+    /// Gets the job status (e.g. <c>queue</c>, <c>hold</c>, <c>done</c>, <c>canceled</c>, <c>draft</c>).
+    /// </summary>
+    public string? Status { get; init; }
+
+    /// <summary>
+    /// Gets the dispatch date, if set.
+    /// </summary>
+    public string? DispatchDate { get; init; }
+
+    /// <summary>
+    /// Gets the original file name, if provided.
+    /// </summary>
+    public string? FilenameOriginal { get; init; }
+
+    /// <summary>
+    /// Gets the creation timestamp. The API reports times in German local time (Europe/Berlin).
+    /// </summary>
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    /// <summary>
+    /// Gets the last update timestamp. The API reports times in German local time (Europe/Berlin).
+    /// </summary>
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    /// <summary>
+    /// Gets the recipient items of the job.
+    /// </summary>
+    public IReadOnlyList<PrintJobItem> Items { get; init; } = [];
+}

--- a/src/Parcel.NET.LetterXpress.Letters/Parcel.NET.LetterXpress.Letters.csproj
+++ b/src/Parcel.NET.LetterXpress.Letters/Parcel.NET.LetterXpress.Letters.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Parcel.NET.LetterXpress.Letters</PackageId>
+    <Description>LetterXpress (A&amp;O Fischer) API v3 client for Parcel.NET — print jobs, SMART@MAIL e-mail jobs, balance, price, transactions, and invoices.</Description>
+    <PackageTags>letter;mail;post;smartmail;logistics;letterxpress</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Parcel.NET.Abstractions kommt transitiv ueber Parcel.NET.LetterXpress (LetterXpressException). -->
+    <ProjectReference Include="..\Parcel.NET.LetterXpress\Parcel.NET.LetterXpress.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Parcel.NET.LetterXpress.Letters.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Parcel.NET.LetterXpress/Internal/LetterXpressErrorHelper.cs
+++ b/src/Parcel.NET.LetterXpress/Internal/LetterXpressErrorHelper.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Parcel.NET.LetterXpress.Internal;
+
+internal static class LetterXpressErrorHelper
+{
+    internal static string TryParseErrorDetail(string rawBody)
+    {
+        if (string.IsNullOrWhiteSpace(rawBody))
+        {
+            return rawBody;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(rawBody);
+            if (doc.RootElement.TryGetProperty("message", out var message))
+            {
+                return message.GetString() ?? rawBody;
+            }
+            if (doc.RootElement.TryGetProperty("error", out var error))
+            {
+                return error.GetString() ?? rawBody;
+            }
+        }
+        catch (JsonException)
+        {
+            // Fall through - raw body is not valid JSON
+        }
+
+        return rawBody;
+    }
+}

--- a/src/Parcel.NET.LetterXpress/LetterXpressBuilder.cs
+++ b/src/Parcel.NET.LetterXpress/LetterXpressBuilder.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Parcel.NET.LetterXpress;
+
+/// <summary>
+/// Builder for chaining LetterXpress sub-service registrations after calling
+/// <see cref="LetterXpressServiceCollectionExtensions.AddLetterXpress"/>.
+/// </summary>
+public class LetterXpressBuilder
+{
+    /// <summary>
+    /// Gets the underlying service collection.
+    /// </summary>
+    public IServiceCollection Services { get; }
+
+    internal LetterXpressBuilder(IServiceCollection services)
+    {
+        Services = services;
+    }
+}

--- a/src/Parcel.NET.LetterXpress/LetterXpressException.cs
+++ b/src/Parcel.NET.LetterXpress/LetterXpressException.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using Parcel.NET.Abstractions.Exceptions;
+
+namespace Parcel.NET.LetterXpress;
+
+/// <summary>
+/// Exception thrown when a LetterXpress API operation fails.
+/// </summary>
+public class LetterXpressException : ParcelException
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="LetterXpressException"/>.
+    /// </summary>
+    public LetterXpressException(string message) : base(message) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LetterXpressException"/> with an inner exception.
+    /// </summary>
+    public LetterXpressException(string message, Exception innerException)
+        : base(message, innerException) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LetterXpressException"/> with carrier API error details.
+    /// </summary>
+    public LetterXpressException(
+        string message,
+        HttpStatusCode? statusCode,
+        string? errorCode,
+        string? rawResponse,
+        Exception? innerException = null)
+        : base(message, statusCode, errorCode, rawResponse, innerException) { }
+}

--- a/src/Parcel.NET.LetterXpress/LetterXpressOptions.cs
+++ b/src/Parcel.NET.LetterXpress/LetterXpressOptions.cs
@@ -1,0 +1,50 @@
+namespace Parcel.NET.LetterXpress;
+
+/// <summary>
+/// Configuration options for the LetterXpress (A&amp;O Fischer) API v3 integration.
+/// </summary>
+public class LetterXpressOptions
+{
+    private const string ProductionBaseUrl = "https://api.letterxpress.de/v3/";
+
+    /// <summary>
+    /// Gets or sets the LetterXpress account username.
+    /// Generated under "Mein Konto &gt; Zugangsdaten &gt; LXP API".
+    /// </summary>
+    public required string Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the LetterXpress API key.
+    /// Generated under "Mein Konto &gt; Zugangsdaten &gt; LXP API".
+    /// </summary>
+    public required string ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the LetterXpress test mode.
+    /// In test mode (<c>"mode": "test"</c>) submitted jobs are not processed but stored in the
+    /// "Postbox" where they can be reviewed, deleted, or sent. Postbox jobs are deleted after 7 days.
+    /// When <see langword="false"/>, jobs are processed directly (<c>"mode": "live"</c>).
+    /// </summary>
+    public bool UseTestMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom base URL override.
+    /// When set, this takes precedence over the default production URL.
+    /// </summary>
+    public string? CustomBaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets the effective API base URL. Uses <see cref="CustomBaseUrl"/> if set,
+    /// otherwise the production URL. A trailing slash is appended if missing so that
+    /// relative request URIs (e.g. <c>balance</c>, <c>printjobs</c>) resolve correctly.
+    /// </summary>
+    public string BaseUrl => EnsureTrailingSlash(CustomBaseUrl) ?? ProductionBaseUrl;
+
+    private static string? EnsureTrailingSlash(string? url) =>
+        url is null ? null : url.EndsWith('/') ? url : url + "/";
+
+    /// <summary>
+    /// Gets the <c>mode</c> value sent in the request <c>auth</c> object (<c>test</c> or <c>live</c>).
+    /// </summary>
+    internal string Mode => UseTestMode ? "test" : "live";
+}

--- a/src/Parcel.NET.LetterXpress/LetterXpressServiceCollectionExtensions.cs
+++ b/src/Parcel.NET.LetterXpress/LetterXpressServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Parcel.NET.LetterXpress;
+
+/// <summary>
+/// Extension methods for registering LetterXpress services with the dependency injection container.
+/// </summary>
+public static class LetterXpressServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds LetterXpress core services including configuration validation.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Action to configure <see cref="LetterXpressOptions"/>.</param>
+    /// <returns>A <see cref="LetterXpressBuilder"/> for chaining LetterXpress sub-service registrations.</returns>
+    public static LetterXpressBuilder AddLetterXpress(this IServiceCollection services, Action<LetterXpressOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptionsWithValidateOnStart<LetterXpressOptions>()
+            .Configure(configure)
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Username), "LetterXpress Username is required.")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.ApiKey), "LetterXpress ApiKey is required.")
+            .Validate(o => IsHttpsOrLocalhost(o.CustomBaseUrl), "CustomBaseUrl must use HTTPS.");
+
+        return new LetterXpressBuilder(services);
+    }
+
+    private static bool IsHttpsOrLocalhost(string? url)
+    {
+        if (url is null) return true;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        if (uri.Scheme == Uri.UriSchemeHttps) return true;
+
+        var host = uri.Host;
+        return host is "localhost" or "127.0.0.1" or "::1";
+    }
+}

--- a/src/Parcel.NET.LetterXpress/Parcel.NET.LetterXpress.csproj
+++ b/src/Parcel.NET.LetterXpress/Parcel.NET.LetterXpress.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Parcel.NET.LetterXpress</PackageId>
+    <Description>LetterXpress (A&amp;O Fischer) authentication, shared configuration, and DI extensions for Parcel.NET.</Description>
+    <PackageTags>letter;mail;post;logistics;letterxpress;authentication</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Parcel.NET.Abstractions\Parcel.NET.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Parcel.NET.LetterXpress.Letters" />
+    <InternalsVisibleTo Include="Parcel.NET.LetterXpress.Letters.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Parcel.NET.LetterXpress.Letters.Tests/LetterXpressClientCoverageTests.cs
+++ b/tests/Parcel.NET.LetterXpress.Letters.Tests/LetterXpressClientCoverageTests.cs
@@ -1,0 +1,355 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Parcel.NET.LetterXpress.Letters.Models;
+using Shouldly;
+using Xunit;
+
+namespace Parcel.NET.LetterXpress.Letters.Tests;
+
+public class LetterXpressClientCoverageTests
+{
+    private static readonly byte[] SamplePdf = Encoding.UTF8.GetBytes("%PDF-1.4 sample");
+
+    private static (LetterXpressClient Client, MockHttpMessageHandler Handler) CreateClient(
+        string responseBody, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        var handler = new MockHttpMessageHandler(responseBody, status);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.letterxpress.de/v3/") };
+        var options = Options.Create(new LetterXpressOptions { Username = "u", ApiKey = "k" });
+        return (new LetterXpressClient(httpClient, options), handler);
+    }
+
+    private static JsonElement BodyRoot(MockHttpMessageHandler handler) =>
+        JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+
+    private static LetterRequest BasicLetter() => new()
+    {
+        File = SamplePdf,
+        Specification = new LetterSpecification { Shipping = ShippingType.National }
+    };
+
+    private const string OkPrintJob = """{"status":200,"message":"OK","data":{"id":1,"status":"queue"}}""";
+
+    // ---- Validation -----------------------------------------------------
+
+    [Fact]
+    public async Task CreatePrintJobAsync_EmptyFile_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+        var req = new LetterRequest { File = [], Specification = new LetterSpecification() };
+
+        await Should.ThrowAsync<ArgumentException>(() => client.CreatePrintJobAsync(req));
+    }
+
+    [Fact]
+    public async Task CreateEmailJobAsync_SerialAndEmailCombined_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        req.SerialLetter = new SerialLetterOptions { PagesSeparatorType = SeparatorType.Number, PagesSeparatorValue = "2" };
+        req.EmailLetter = new EmailLetterOptions { EmailOption = EmailOption.MailDirect, EmailReceiver = "a@x.de" };
+
+        await Should.ThrowAsync<ArgumentException>(() => client.CreateEmailJobAsync(req));
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_RegisteredInternational_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+        var req = new LetterRequest
+        {
+            File = SamplePdf,
+            Specification = new LetterSpecification { Shipping = ShippingType.International },
+            Registered = RegisteredMail.Einschreiben
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => client.CreatePrintJobAsync(req));
+    }
+
+    [Fact]
+    public async Task GetPriceAsync_AutoShipping_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            client.GetPriceAsync(new PriceRequest { Pages = 1, Shipping = ShippingType.Auto }));
+    }
+
+    [Fact]
+    public async Task GetPriceAsync_NonPositivePages_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            client.GetPriceAsync(new PriceRequest { Pages = 0, Shipping = ShippingType.National }));
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_SerialNumberWithNonNumericValue_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        req.SerialLetter = new SerialLetterOptions { PagesSeparatorType = SeparatorType.Number, PagesSeparatorValue = "abc" };
+
+        await Should.ThrowAsync<ArgumentException>(() => client.CreatePrintJobAsync(req));
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_PastDispatchDate_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        req.DispatchDate = new DateOnly(2000, 1, 1);
+
+        await Should.ThrowAsync<ArgumentException>(() => client.CreatePrintJobAsync(req));
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_OversizedAttachmentsTotal_Throws()
+    {
+        var (client, _) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        // Main file is tiny, but an attachment pushes the request over the 50 MB limit.
+        req.Attachments = [new byte[51 * 1024 * 1024]];
+
+        await Should.ThrowAsync<ArgumentException>(() => client.CreatePrintJobAsync(req));
+    }
+
+    // ---- Serial letter separator serialization --------------------------
+
+    [Fact]
+    public async Task CreatePrintJobAsync_SerialNumber_SerializesAsJsonNumber()
+    {
+        var (client, handler) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        req.SerialLetter = new SerialLetterOptions { PagesSeparatorType = SeparatorType.Number, PagesSeparatorValue = "3" };
+
+        await client.CreatePrintJobAsync(req);
+
+        var serial = BodyRoot(handler).GetProperty("letter").GetProperty("serial_letter");
+        serial.GetProperty("pages_separator_type").GetString().ShouldBe("number");
+        var value = serial.GetProperty("pages_separator_value");
+        value.ValueKind.ShouldBe(JsonValueKind.Number);
+        value.GetInt32().ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_SerialString_SerializesAsJsonString()
+    {
+        var (client, handler) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        req.SerialLetter = new SerialLetterOptions { PagesSeparatorType = SeparatorType.String, PagesSeparatorValue = "TRENN" };
+
+        await client.CreatePrintJobAsync(req);
+
+        var value = BodyRoot(handler).GetProperty("letter").GetProperty("serial_letter").GetProperty("pages_separator_value");
+        value.ValueKind.ShouldBe(JsonValueKind.String);
+        value.GetString().ShouldBe("TRENN");
+    }
+
+    // ---- Complex payload building ---------------------------------------
+
+    [Fact]
+    public async Task CreatePrintJobAsync_AttachmentsAndBankForm_Serialized()
+    {
+        var (client, handler) = CreateClient(OkPrintJob);
+        var req = BasicLetter();
+        req.Attachments = [Encoding.UTF8.GetBytes("att1")];
+        req.BankForm = new BankForm { Included = false, Iban = "DE0001", Amount = "12,00" };
+
+        await client.CreatePrintJobAsync(req);
+
+        var letter = BodyRoot(handler).GetProperty("letter");
+        var attachments = letter.GetProperty("base64_attachments");
+        attachments.GetArrayLength().ShouldBe(1);
+        attachments[0].GetString().ShouldBe(Convert.ToBase64String(Encoding.UTF8.GetBytes("att1")));
+
+        var bank = letter.GetProperty("bank_form");
+        bank.GetProperty("bank_form_included").GetInt32().ShouldBe(0);
+        bank.GetProperty("iban").GetString().ShouldBe("DE0001");
+    }
+
+    // ---- Update partial-spec --------------------------------------------
+
+    [Fact]
+    public async Task UpdatePrintJobAsync_NoticeOnly_OmitsSpecification()
+    {
+        var (client, handler) = CreateClient(OkPrintJob);
+
+        await client.UpdatePrintJobAsync(1, new PrintJobUpdate { Notice = "only notice" });
+
+        var letter = BodyRoot(handler).GetProperty("letter");
+        letter.GetProperty("notice").GetString().ShouldBe("only notice");
+        letter.TryGetProperty("specification", out _).ShouldBeFalse();
+        letter.TryGetProperty("dispatch_date", out _).ShouldBeFalse();
+        letter.TryGetProperty("registered", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task UpdatePrintJobAsync_ColorOnly_SendsPartialSpecification()
+    {
+        var (client, handler) = CreateClient(OkPrintJob);
+
+        await client.UpdatePrintJobAsync(1, new PrintJobUpdate { Color = LetterColor.Color });
+
+        var spec = BodyRoot(handler).GetProperty("letter").GetProperty("specification");
+        spec.GetProperty("color").GetString().ShouldBe("4");
+        spec.TryGetProperty("mode", out _).ShouldBeFalse();
+        spec.TryGetProperty("shipping", out _).ShouldBeFalse();
+        spec.TryGetProperty("c4", out _).ShouldBeFalse();
+    }
+
+    // ---- Body-level error -----------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_BodyLevelStatusError_ThrowsWithStatusCode()
+    {
+        // HTTP 200 but the body reports an application-level error.
+        const string json = """{"status":400,"message":"Bad Request"}""";
+        var (client, _) = CreateClient(json, HttpStatusCode.OK);
+
+        var ex = await Should.ThrowAsync<LetterXpressException>(() => client.GetBalanceAsync());
+
+        ex.ErrorCode.ShouldBe("400");
+        ex.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        ex.RawResponse.ShouldNotBeNull();
+        ex.RawResponse!.ShouldContain("Bad Request");
+    }
+
+    // ---- Missing endpoint coverage --------------------------------------
+
+    [Fact]
+    public async Task GetPrintJobAsync_ReturnsRenderedPdf()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"id":99,"status":"done","c4":0,"bank_form":0,"items":[{"address":"X","pages":1,"amount":0.67,"vat":0.13,"status":"sent","tracking_code":"RC1DE","base64_data":"QUJD"}]}}
+            """;
+        var (client, handler) = CreateClient(json);
+
+        var job = await client.GetPrintJobAsync(99);
+
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.AbsolutePath.ShouldEndWith("/v3/printjobs/99");
+        var item = job.Items.ShouldHaveSingleItem();
+        item.TrackingCode.ShouldBe("RC1DE");
+        item.Base64Data.ShouldBe("QUJD");
+    }
+
+    [Fact]
+    public async Task GetEmailJobAsync_MapsNestedPrintJob()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"id":918,"email_receiver":"j@aof.de","email_option":"mailplus","amount":0.1,"vat":0.02,"status":"success","printjob":{"id":138037,"status":"done","c4":0,"bank_form":0,"items":[{"address":"X","pages":1,"amount":0.67,"vat":0.13,"status":"sent"}]}}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var job = await client.GetEmailJobAsync(918);
+
+        job.Id.ShouldBe(918);
+        job.PrintJob.ShouldNotBeNull();
+        job.PrintJob!.Id.ShouldBe(138037);
+    }
+
+    [Fact]
+    public async Task DeleteEmailJobAsync_UsesDeleteMethod()
+    {
+        const string json = """{"status":200,"message":"Email job deleted successfully"}""";
+        var (client, handler) = CreateClient(json);
+
+        await client.DeleteEmailJobAsync(3902);
+
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Delete);
+        handler.LastRequest.RequestUri!.AbsolutePath.ShouldEndWith("/v3/emailjobs/3902");
+    }
+
+    [Fact]
+    public async Task UpdateEmailJobAsync_SendsNewReceiver()
+    {
+        const string json = """{"status":200,"message":"OK","data":{"id":3902,"email_receiver":"new@aof.de","email_option":"maildirect","amount":0.05,"vat":0.01,"status":"queue"}}""";
+        var (client, handler) = CreateClient(json);
+
+        var job = await client.UpdateEmailJobAsync(3902, "new@aof.de");
+
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Put);
+        BodyRoot(handler).GetProperty("email").GetProperty("email_receiver").GetString().ShouldBe("new@aof.de");
+        job.EmailReceiver.ShouldBe("new@aof.de");
+    }
+
+    [Fact]
+    public async Task ListEmailJobsAsync_WithFilter_ParsesAndBuildsQuery()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"emailjobs":[{"id":3093,"email_receiver":"j@aof.de","email_option":"mailplus","amount":0.1,"vat":0.02,"status":"hold"}],"pagination":{"total":1,"count":1,"current_page":1,"last_page":1,"per_page":15,"first_page_url":"https://api.letterxpress.de/v3/emailjobs?page=1","last_page_url":"https://api.letterxpress.de/v3/emailjobs?page=1"}}}
+            """;
+        var (client, handler) = CreateClient(json);
+
+        var result = await client.ListEmailJobsAsync(EmailJobFilter.Hold);
+
+        handler.LastRequest!.RequestUri!.Query.ShouldContain("filter=hold");
+        result.Items.ShouldHaveSingleItem().Id.ShouldBe(3093);
+        result.Pagination!.FirstPageUrl.ShouldNotBeNull();
+        result.Pagination.LastPageUrl.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ListInvoicesAsync_MapsItems()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"invoices":[{"id":25402,"amount":0.67,"vat":0.13,"invoice_date":"2020-05-31"}],"pagination":{"total":1,"count":1,"current_page":1,"last_page":1,"per_page":15}}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var result = await client.ListInvoicesAsync();
+
+        var inv = result.Items.ShouldHaveSingleItem();
+        inv.Id.ShouldBe(25402);
+        inv.InvoiceDate.ShouldBe(new DateOnly(2020, 5, 31));
+    }
+
+    [Fact]
+    public async Task ListPrintJobsAsync_NoFilterOrPage_HasNoQuery()
+    {
+        const string json = """{"status":200,"message":"OK","data":{"printjobs":[],"pagination":{"total":0,"count":0,"current_page":1,"last_page":1,"per_page":50}}}""";
+        var (client, handler) = CreateClient(json);
+
+        await client.ListPrintJobsAsync();
+
+        handler.LastRequest!.RequestUri!.Query.ShouldBeEmpty();
+    }
+
+    // ---- Timezone (DST) -------------------------------------------------
+
+    [Fact]
+    public async Task ParseDateTime_WinterDate_UsesCetPlusOne()
+    {
+        var berlin = TryGetBerlin();
+        if (berlin is null)
+        {
+            Assert.Skip("Europe/Berlin timezone data not available on this machine.");
+        }
+
+        const string json = """
+            {"status":200,"message":"OK","data":{"transactions":[{"amount":-1.0,"currency":"EUR","description":"x","created_at":"2024-01-15 09:00:00"}],"pagination":{"total":1,"count":1,"current_page":1,"last_page":1,"per_page":15}}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var result = await client.ListTransactionsAsync();
+
+        // January => CET (UTC+1).
+        result.Items.ShouldHaveSingleItem().CreatedAt
+            .ShouldBe(new DateTimeOffset(2024, 1, 15, 9, 0, 0, TimeSpan.FromHours(1)));
+    }
+
+    private static TimeZoneInfo? TryGetBerlin()
+    {
+        foreach (var id in (string[])["Europe/Berlin", "W. Europe Standard Time"])
+        {
+            try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
+            catch (TimeZoneNotFoundException) { }
+            catch (InvalidTimeZoneException) { }
+        }
+        return null;
+    }
+}

--- a/tests/Parcel.NET.LetterXpress.Letters.Tests/LetterXpressClientTests.cs
+++ b/tests/Parcel.NET.LetterXpress.Letters.Tests/LetterXpressClientTests.cs
@@ -1,0 +1,305 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Parcel.NET.LetterXpress.Letters.Models;
+using Shouldly;
+using Xunit;
+
+namespace Parcel.NET.LetterXpress.Letters.Tests;
+
+public class LetterXpressClientTests
+{
+    private static readonly byte[] SamplePdf = Encoding.UTF8.GetBytes("%PDF-1.4 sample");
+
+    private static (LetterXpressClient Client, MockHttpMessageHandler Handler) CreateClient(
+        string responseBody, HttpStatusCode status = HttpStatusCode.OK, bool testMode = false)
+    {
+        var handler = new MockHttpMessageHandler(responseBody, status);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.letterxpress.de/v3/") };
+        var options = Options.Create(new LetterXpressOptions
+        {
+            Username = "testuser",
+            ApiKey = "secret-key",
+            UseTestMode = testMode
+        });
+        return (new LetterXpressClient(httpClient, options), handler);
+    }
+
+    private static JsonElement BodyRoot(MockHttpMessageHandler handler) =>
+        JsonDocument.Parse(handler.LastRequestBody!).RootElement;
+
+    [Fact]
+    public async Task GetBalanceAsync_ReturnsBalance()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"balance":54.89,"currency":"EUR"}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var balance = await client.GetBalanceAsync();
+
+        balance.Amount.ShouldBe(54.89m);
+        balance.Currency.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public async Task GetBalanceAsync_SendsAuthInBody()
+    {
+        const string json = """{"status":200,"message":"OK","data":{"balance":1,"currency":"EUR"}}""";
+        var (client, handler) = CreateClient(json, testMode: true);
+
+        await client.GetBalanceAsync();
+
+        var auth = BodyRoot(handler).GetProperty("auth");
+        auth.GetProperty("username").GetString().ShouldBe("testuser");
+        auth.GetProperty("apikey").GetString().ShouldBe("secret-key");
+        auth.GetProperty("mode").GetString().ShouldBe("test");
+    }
+
+    [Fact]
+    public async Task GetBalanceAsync_UsesGetMethod()
+    {
+        const string json = """{"status":200,"message":"OK","data":{"balance":1,"currency":"EUR"}}""";
+        var (client, handler) = CreateClient(json);
+
+        await client.GetBalanceAsync();
+
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.AbsolutePath.ShouldEndWith("/v3/balance");
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_EncodesFileAndChecksum()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"id":6035143,"shipping":"national","mode":"simplex","color":"4","c4":0,"bank_form":0,"status":"queue","created_at":"2022-08-01 13:38:07","updated_at":"2022-08-01 13:38:07","items":[{"address":"Jim Knopf","pages":1,"amount":0.68,"vat":0.13,"status":"queue"}]}}
+            """;
+        var (client, handler) = CreateClient(json);
+
+        var job = await client.CreatePrintJobAsync(new LetterRequest
+        {
+            File = SamplePdf,
+            Specification = new LetterSpecification
+            {
+                Color = LetterColor.Color,
+                Mode = PrintMode.Simplex,
+                Shipping = ShippingType.National
+            }
+        });
+
+        var letter = BodyRoot(handler).GetProperty("letter");
+        var expectedBase64 = Convert.ToBase64String(SamplePdf);
+        var expectedChecksum = Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(expectedBase64))).ToLowerInvariant();
+
+        letter.GetProperty("base64_file").GetString().ShouldBe(expectedBase64);
+        letter.GetProperty("base64_file_checksum").GetString().ShouldBe(expectedChecksum);
+        letter.GetProperty("specification").GetProperty("color").GetString().ShouldBe("4");
+        letter.GetProperty("specification").GetProperty("shipping").GetString().ShouldBe("national");
+
+        job.Id.ShouldBe(6035143);
+        job.Status.ShouldBe("queue");
+        job.Items.ShouldHaveSingleItem().Amount.ShouldBe(0.68m);
+    }
+
+    [Fact]
+    public async Task CreatePrintJobAsync_MapsRegisteredAndDispatchDate()
+    {
+        const string json = """{"status":200,"message":"OK","data":{"id":1,"status":"queue"}}""";
+        var (client, handler) = CreateClient(json);
+
+        await client.CreatePrintJobAsync(new LetterRequest
+        {
+            File = SamplePdf,
+            Specification = new LetterSpecification { Shipping = ShippingType.National },
+            Registered = RegisteredMail.EinschreibenEinwurf,
+            DispatchDate = new DateOnly(2026, 9, 1),
+            Notice = "KdNr. 4711"
+        });
+
+        var letter = BodyRoot(handler).GetProperty("letter");
+        letter.GetProperty("registered").GetString().ShouldBe("r1");
+        letter.GetProperty("dispatch_date").GetString().ShouldBe("2026-09-01");
+        letter.GetProperty("notice").GetString().ShouldBe("KdNr. 4711");
+    }
+
+    [Fact]
+    public async Task GetPriceAsync_SendsPagesAndReturnsPrice()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"price":4.99,"letter":{"specification":{"pages":1,"color":"4","mode":"simplex","shipping":"national"}}}}
+            """;
+        var (client, handler) = CreateClient(json);
+
+        var price = await client.GetPriceAsync(new PriceRequest
+        {
+            Pages = 1,
+            Color = LetterColor.Color,
+            Shipping = ShippingType.National,
+            EmailOption = EmailOption.MailSecure
+        });
+
+        var spec = BodyRoot(handler).GetProperty("letter").GetProperty("specification");
+        spec.GetProperty("pages").GetInt32().ShouldBe(1);
+        spec.GetProperty("email_option").GetString().ShouldBe("mailsecure");
+
+        price.Price.ShouldBe(4.99m);
+        price.Pages.ShouldBe(1);
+        price.Shipping.ShouldBe("national");
+    }
+
+    [Fact]
+    public async Task ListPrintJobsAsync_BuildsFilterAndPageQuery()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"printjobs":[{"id":1,"status":"hold","c4":0,"bank_form":0,"items":[]}],"pagination":{"total":7,"count":7,"current_page":1,"last_page":1,"per_page":15}}}
+            """;
+        var (client, handler) = CreateClient(json);
+
+        var result = await client.ListPrintJobsAsync(PrintJobFilter.Hold, page: 2);
+
+        handler.LastRequest!.RequestUri!.Query.ShouldContain("filter=hold");
+        handler.LastRequest.RequestUri.Query.ShouldContain("page=2");
+        result.Items.ShouldHaveSingleItem().Id.ShouldBe(1);
+        result.Pagination!.Total.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task DeletePrintJobAsync_UsesDeleteMethod()
+    {
+        const string json = """{"status":200,"message":"Print job deleted successfully"}""";
+        var (client, handler) = CreateClient(json);
+
+        await client.DeletePrintJobAsync(6035143);
+
+        handler.LastRequest!.Method.ShouldBe(HttpMethod.Delete);
+        handler.LastRequest.RequestUri!.AbsolutePath.ShouldEndWith("/v3/printjobs/6035143");
+    }
+
+    [Fact]
+    public async Task CreateEmailJobAsync_SingleObject_ReturnsOneEmailJob()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"id":3096,"email_receiver":"max@letterxpress.email","email_option":"mailplus","amount":0.1,"vat":0.02,"status":"queue","subject":"Ihre Rechnung"}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var result = await client.CreateEmailJobAsync(new LetterRequest
+        {
+            File = SamplePdf,
+            Specification = new LetterSpecification(),
+            EmailLetter = new EmailLetterOptions { EmailOption = EmailOption.MailPlus, EmailReceiver = "max@letterxpress.email" }
+        });
+
+        var job = result.EmailJobs.ShouldHaveSingleItem();
+        job.Id.ShouldBe(3096);
+        job.EmailOption.ShouldBe("mailplus");
+        result.PrintJobs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateEmailJobAsync_Array_ReturnsMultipleEmailJobs()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":[{"id":3813,"email_receiver":"a@x.de","email_option":"maildirect","amount":0.05,"vat":0.01,"status":"queue"},{"id":3814,"email_receiver":"b@x.de","email_option":"maildirect","amount":0.05,"vat":0.01,"status":"queue"}]}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var result = await client.CreateEmailJobAsync(new LetterRequest
+        {
+            File = SamplePdf,
+            Specification = new LetterSpecification()
+        });
+
+        result.EmailJobs.Count.ShouldBe(2);
+        result.EmailJobs[1].Id.ShouldBe(3814);
+    }
+
+    [Fact]
+    public async Task CreateEmailJobAsync_CombinedPrintAndEmail_ReturnsBoth()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"printjobs":[{"id":138606,"status":"queue","c4":0,"bank_form":0,"items":[]}],"emailjobs":[{"id":3837,"email_receiver":"a@x.de","email_option":"mailplus","amount":0.1,"vat":0.02,"status":"queue","printjob_id":138606}]}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var result = await client.CreateEmailJobAsync(new LetterRequest
+        {
+            File = SamplePdf,
+            Specification = new LetterSpecification()
+        });
+
+        result.PrintJobs.ShouldHaveSingleItem().Id.ShouldBe(138606);
+        var job = result.EmailJobs.ShouldHaveSingleItem();
+        job.PrintJobId.ShouldBe(138606);
+    }
+
+    [Fact]
+    public async Task GetInvoiceAsync_ReturnsInvoiceWithPdf()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"id":25402,"amount":0.67,"vat":0.13,"invoice_date":"2020-05-31","base64_data":"xxxxxxxx"}}
+            """;
+        var (client, _) = CreateClient(json);
+
+        var invoice = await client.GetInvoiceAsync(25402);
+
+        invoice.Id.ShouldBe(25402);
+        invoice.InvoiceDate.ShouldBe(new DateOnly(2020, 5, 31));
+        invoice.Base64Data.ShouldBe("xxxxxxxx");
+    }
+
+    [Fact]
+    public async Task ListTransactionsAsync_MapsItems()
+    {
+        const string json = """
+            {"status":200,"message":"OK","data":{"transactions":[{"amount":-1.04,"currency":"EUR","description":"Farbe","created_at":"2022-09-21 15:32:45"}],"pagination":{"total":62,"count":15,"current_page":1,"last_page":5,"per_page":15,"next_page_url":"http://api.letterxpress.de/v3/transactions?page=2"}}}
+            """;
+        var (client, handler) = CreateClient(json);
+
+        var result = await client.ListTransactionsAsync(TransactionFilter.PrintJobs);
+
+        handler.LastRequest!.RequestUri!.Query.ShouldContain("filter=printjobs");
+        var item = result.Items.ShouldHaveSingleItem();
+        item.Amount.ShouldBe(-1.04m);
+        // Timestamps are German local time (Europe/Berlin). September => CEST (UTC+2).
+        item.CreatedAt.ShouldBe(new DateTimeOffset(2022, 9, 21, 15, 32, 45, TimeSpan.FromHours(2)));
+        result.Pagination!.NextPageUrl.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_SetsContentTypeWithoutCharset()
+    {
+        // The live API rejects "application/json; charset=utf-8" with HTTP 400.
+        const string json = """{"status":200,"message":"OK","data":{"balance":1,"currency":"EUR"}}""";
+        var (client, handler) = CreateClient(json);
+
+        await client.GetBalanceAsync();
+
+        handler.LastRequest!.Content!.Headers.ContentType!.ToString().ShouldBe("application/json");
+    }
+
+    [Fact]
+    public async Task UnauthorizedResponse_ThrowsLetterXpressException()
+    {
+        const string json = """{"message":"Unauthorized."}""";
+        var (client, _) = CreateClient(json, HttpStatusCode.Unauthorized);
+
+        var ex = await Should.ThrowAsync<LetterXpressException>(() => client.GetBalanceAsync());
+
+        ex.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        ex.Message.ShouldContain("Unauthorized");
+    }
+
+    [Fact]
+    public async Task LiveMode_SendsLiveInAuth()
+    {
+        const string json = """{"status":200,"message":"OK","data":{"balance":1,"currency":"EUR"}}""";
+        var (client, handler) = CreateClient(json, testMode: false);
+
+        await client.GetBalanceAsync();
+
+        BodyRoot(handler).GetProperty("auth").GetProperty("mode").GetString().ShouldBe("live");
+    }
+}

--- a/tests/Parcel.NET.LetterXpress.Letters.Tests/MockHttpMessageHandler.cs
+++ b/tests/Parcel.NET.LetterXpress.Letters.Tests/MockHttpMessageHandler.cs
@@ -1,0 +1,36 @@
+using System.Net;
+
+namespace Parcel.NET.LetterXpress.Letters.Tests;
+
+/// <summary>
+/// Test handler that captures the outgoing request (method, URI, and body) and returns a queued response.
+/// </summary>
+internal sealed class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode _statusCode;
+    private readonly string _responseBody;
+
+    public HttpRequestMessage? LastRequest { get; private set; }
+    public string? LastRequestBody { get; private set; }
+
+    public MockHttpMessageHandler(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _responseBody = responseBody;
+        _statusCode = statusCode;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        if (request.Content is not null)
+        {
+            LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_responseBody),
+        };
+    }
+}

--- a/tests/Parcel.NET.LetterXpress.Letters.Tests/Parcel.NET.LetterXpress.Letters.Tests.csproj
+++ b/tests/Parcel.NET.LetterXpress.Letters.Tests/Parcel.NET.LetterXpress.Letters.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Parcel.NET.LetterXpress.Letters\Parcel.NET.LetterXpress.Letters.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds **LetterXpress** (A&O Fischer GmbH & Co. KG) as a new carrier — a print-and-mail service (upload a PDF, it's printed and posted, optionally via SMART@MAIL e-mail).

Because it's a letter/print-mail product rather than a parcel carrier, it does **not** implement `IShipmentService`/`ITrackingService`; it exposes its own `ILetterXpressClient`, mirroring the DHL Internetmarke design.

### Packages
- `Parcel.NET.LetterXpress` — options, builder, DI, exception, error helper
- `Parcel.NET.LetterXpress.Letters` — client: print jobs, SMART@MAIL e-mail jobs, balance, price, transactions, invoices
- `Parcel.NET.LetterXpress.All` — meta-package

### Carrier specifics (verified against the live API)
- **Auth in the JSON body** (`auth` object on every request, incl. GET/DELETE) — no auth header.
- **Content-Type pinned to exactly `application/json`** — the API rejects `; charset=utf-8` with HTTP 400.
- **Timestamps are Europe/Berlin local time** (no TZ in the payload) — parsed DST-aware into `DateTimeOffset`.
- **`EmailJobFilter`** values (`queue/hold/canceled/draft/success`) were probed empirically, not guessed.
- snake_case wire models + source-generated `JsonSerializerContext`; base64 + MD5 computed by the client.

### Validation
Local guards for the 50 MB request limit (incl. attachments/backgrounds/terms), empty file, registered-mail-national-only, serial+email exclusivity, numeric serial separator, future dispatch date, and price page count / shipping.

### Tests
38 unit tests (mocked HTTP). Read and write paths (create → get → delete in test-mode Postbox) were additionally verified against the live API.

### Docs
- API reference now includes the LetterXpress types (generator assembly list extended).
- New guide page under **Carriers > LetterXpress**.

### Release / NuGet
- Per-package release workflows (`letterxpress`, `letterxpress-letters`, `letterxpress-all`), listed in the release-tag dispatcher.
- CI runs the LetterXpress test project.
- ⚠️ Publish order due to dependencies: `letterxpress` → `letterxpress-letters` → `letterxpress-all`.

> Note: LetterXpress is a server-to-server API and intentionally has no CORS, so it is **not** wired into the interactive browser Playground (that would also expose the API key). API reference + guide cover it instead.